### PR TITLE
Add global cluster pull secret support

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -1,4 +1,6 @@
 parameters:
   openshift4_config:
     =_metadata: {}
-    namespace: syn-openshift4-config
+    namespace: openshift4-config
+    dockerCredentials:
+      secretName: pull-secret

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -1,6 +1,6 @@
 parameters:
   openshift4_config:
     =_metadata: {}
-    namespace: openshift4-config
+    namespace: openshift-config
     dockerCredentials:
       secretName: pull-secret

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -1,6 +1,4 @@
 parameters:
   openshift4_config:
     =_metadata: {}
-    namespace: openshift-config
-    dockerCredentials:
-      secretName: pull-secret
+    globalPullSecret: null

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -5,16 +5,16 @@ local inv = kap.inventory();
 // The hiera parameters for the component
 local params = inv.parameters.openshift4_config;
 
-local dockercfg = kube.Secret(params.dockerCredentials.secretName) {
+local dockercfg = kube.Secret('pull-secret') {
   metadata+: {
-    namespace: params.namespace,
+    namespace: 'openshift-config',
   },
   stringData+: {
-    '.dockerconfigjson': params.dockerCredentials.dockerconfigjson,
+    '.dockerconfigjson': params.globalPullSecret,
   },
 };
 
 // Define outputs below
 {
-  '01_dockercfg': dockercfg,
+  [if params.globalPullSecret != null then '01_dockercfg']: dockercfg,
 }

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -5,6 +5,16 @@ local inv = kap.inventory();
 // The hiera parameters for the component
 local params = inv.parameters.openshift4_config;
 
+local dockercfg = kube.Secret(params.dockerCredentials.secretName) {
+  metadata+: {
+    namespace: params.namespace,
+  },
+  data+: {
+    '.dockerconfigjson': params.dockerCredentials.dockerconfigjson,
+  },
+};
+
 // Define outputs below
 {
+  '01_dockercfg': dockercfg,
 }

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -9,7 +9,7 @@ local dockercfg = kube.Secret(params.dockerCredentials.secretName) {
   metadata+: {
     namespace: params.namespace,
   },
-  data+: {
+  stringData+: {
     '.dockerconfigjson': params.dockerCredentials.dockerconfigjson,
   },
 };

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -1,5 +1,5 @@
 = openshift4-config
 
-openshift4-config is a Commodore component to manage openshift4-config.
+openshift4-config is a Commodore component to manage openshift4-config. This component updates global cluster pull secrets as described in the openshift https://docs.openshift.com/container-platform/latest/openshift_images/managing_images/using-image-pull-secrets.html#images-update-global-pull-secret_using-image-pull-secrets[docs]
 
 See the xref:references/parameters.adoc[parameters] reference for further details.

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -1,5 +1,7 @@
 = openshift4-config
 
-openshift4-config is a Commodore component to manage openshift4-config. This component updates global cluster pull secrets as described in the openshift https://docs.openshift.com/container-platform/latest/openshift_images/managing_images/using-image-pull-secrets.html#images-update-global-pull-secret_using-image-pull-secrets[docs]
+openshift4-config is a Commodore component to manage openshift4-config.
+
+Currently, this component can manage the global cluster pull secret as described in the https://docs.openshift.com/container-platform/latest/openshift_images/managing_images/using-image-pull-secrets.html#images-update-global-pull-secret_using-image-pull-secret[OpenShift documentation].
 
 See the xref:references/parameters.adoc[parameters] reference for further details.

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -8,4 +8,15 @@ The parent key for all the following parameters is `openshift4_config`.
 type:: string
 default:: null
 
-A vault reference pointing to the Vault secret containing docker global pull secret configuration file in json format. If the key is null the manifest isn't created. If the key isn’t provided as a vault reference, the secret key must be provided in its base64 encoded form. It can be generated using the command echo -n '<mySecretKey> | base64.
+A Vault reference pointing to the Vault secret containing the docker configuration file in JSON format.
+If the parameter is null, the component doesn't manage the cluster's global pull secret.
+
+The component writes the value of this parameter into the field `.dockerconfigjson` of the secret `pull-secret` in namespace `openshift-config`.
+
+See the OpenShift documentation for more details on https://docs.openshift.com/container-platform/latest/openshift_images/managing_images/using-image-pull-secrets.html#images-update-global-pull-secret_using-image-pull-secret[managing the cluster's global pull secret].
+
+[IMPORTANT]
+====
+You need to make sure that the existing pull secrets present on a cluster (deployed by the OpenShift installer) are included in the configuration deployed by this component.
+Otherwise, OpenShift cluster services may stop working because their respective container images can't be downloaded anymore.
+====

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -6,14 +6,21 @@ The parent key for all of the following parameters is `openshift4_config`.
 
 [horizontal]
 type:: string
-default:: `syn-openshift4-config`
+default:: `openshift4-config`
 
-The namespace in which to deploy this component.
+The namespace in which the OpenShift configuration takes place
 
+== `dockerCredentials.secretName`
 
-== Example
+[horizontal]
+type:: string
+default:: `pull-secret`
 
-[source,yaml]
-----
-namespace: example-namespace
-----
+The default name for the global cluster pull secret in OpenShift.
+
+== `dockerCredentials.dockerconfigjson`
+
+[horizontal]
+type:: string
+
+A vault reference pointing to the Vault secret containing the docker configuration file in json format. If the key isn’t provided as a vault reference, the secret key must be provided in its base64 encoded form. It can be generated using the command echo -n '<mySecretKey> | base64.

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -1,26 +1,11 @@
 = Parameters
 
-The parent key for all of the following parameters is `openshift4_config`.
+The parent key for all the following parameters is `openshift4_config`.
 
-== `namespace`
-
-[horizontal]
-type:: string
-default:: `openshift4-config`
-
-The namespace in which the OpenShift configuration takes place
-
-== `dockerCredentials.secretName`
+== `globalPullSecret`
 
 [horizontal]
 type:: string
-default:: `pull-secret`
+default:: null
 
-The default name for the global cluster pull secret in OpenShift.
-
-== `dockerCredentials.dockerconfigjson`
-
-[horizontal]
-type:: string
-
-A vault reference pointing to the Vault secret containing the docker configuration file in json format. If the key isn’t provided as a vault reference, the secret key must be provided in its base64 encoded form. It can be generated using the command echo -n '<mySecretKey> | base64.
+A vault reference pointing to the Vault secret containing docker global pull secret configuration file in json format. If the key is null the manifest isn't created. If the key isn’t provided as a vault reference, the secret key must be provided in its base64 encoded form. It can be generated using the command echo -n '<mySecretKey> | base64.

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -1,3 +1,6 @@
-# Overwrite parameters here
-
-# parameters: {...}
+parameters:
+  openshift4_config:
+    namespace: openshift4-config
+    dockerCredentials:
+      secretName: pull-secret
+      dockerconfigjson: ?{vaultkv:${customer:name}/${cluster:name}/openshift4-config/dockercfg}

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -1,6 +1,6 @@
 parameters:
   openshift4_config:
-    namespace: openshift4-config
+    namespace: openshift-config
     dockerCredentials:
       secretName: pull-secret
       dockerconfigjson: ?{vaultkv:${customer:name}/${cluster:name}/openshift4-config/dockercfg}

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -1,6 +1,3 @@
 parameters:
   openshift4_config:
-    namespace: openshift-config
-    dockerCredentials:
-      secretName: pull-secret
-      dockerconfigjson: ?{vaultkv:${customer:name}/${cluster:name}/openshift4-config/dockercfg}
+    globalPullSecret: ?{vaultkv:${customer:name}/${cluster:name}/openshift4-config/dockercfg}

--- a/tests/golden/defaults/openshift4-config/openshift4-config/01_dockercfg.yaml
+++ b/tests/golden/defaults/openshift4-config/openshift4-config/01_dockercfg.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+data:
+  .dockerconfigjson: t-silent-test-1234/c-green-test-1234/openshift4-config/dockercfg
+kind: Secret
+metadata:
+  annotations: {}
+  labels:
+    name: pull-secret
+  name: pull-secret
+  namespace: openshift4-config
+type: Opaque

--- a/tests/golden/defaults/openshift4-config/openshift4-config/01_dockercfg.yaml
+++ b/tests/golden/defaults/openshift4-config/openshift4-config/01_dockercfg.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-data:
+stringData:
   .dockerconfigjson: t-silent-test-1234/c-green-test-1234/openshift4-config/dockercfg
 kind: Secret
 metadata:
@@ -7,5 +7,5 @@ metadata:
   labels:
     name: pull-secret
   name: pull-secret
-  namespace: openshift4-config
+  namespace: openshift-config
 type: Opaque

--- a/tests/golden/defaults/openshift4-config/openshift4-config/01_dockercfg.yaml
+++ b/tests/golden/defaults/openshift4-config/openshift4-config/01_dockercfg.yaml
@@ -1,6 +1,5 @@
 apiVersion: v1
-stringData:
-  .dockerconfigjson: t-silent-test-1234/c-green-test-1234/openshift4-config/dockercfg
+data: {}
 kind: Secret
 metadata:
   annotations: {}
@@ -8,4 +7,6 @@ metadata:
     name: pull-secret
   name: pull-secret
   namespace: openshift-config
+stringData:
+  .dockerconfigjson: t-silent-test-1234/c-green-test-1234/openshift4-config/dockercfg
 type: Opaque


### PR DESCRIPTION
This PR will help manage global pull secret for OpenShift 4 clusters. Later it can be extended to configure other aspects of OpenShift 4.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
