### PR TITLE
Specify secret type for docker pull-secret.

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -12,6 +12,7 @@ local dockercfg = kube.Secret('pull-secret') {
   stringData+: {
     '.dockerconfigjson': params.globalPullSecret,
   },
+  type: 'kubernetes.io/dockerconfigjson',
 };
 
 // Define outputs below

--- a/tests/golden/defaults/openshift4-config/openshift4-config/01_dockercfg.yaml
+++ b/tests/golden/defaults/openshift4-config/openshift4-config/01_dockercfg.yaml
@@ -9,4 +9,4 @@ metadata:
   namespace: openshift-config
 stringData:
   .dockerconfigjson: t-silent-test-1234/c-green-test-1234/openshift4-config/dockercfg
-type: Opaque
+type: kubernetes.io/dockerconfigjson


### PR DESCRIPTION
The default secret type `Opaque` is wrong for pull-secrets.

Signed-off-by: Nicolas Bigler <nicolas.bigler@vshn.ch>




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
