### PR TITLE
Notifications via message of the day for oc login

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -7,7 +7,7 @@
       "name": "openshift4-config",
       "slug": "openshift4-config",
       "parameter_key": "openshift4_config",
-      "test_cases": "defaults pull-secret",
+      "test_cases": "defaults pull-secret motd",
       "add_lib": "n",
       "add_pp": "n",
       "add_golden": "y",

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,6 +34,7 @@ jobs:
         instance:
           - defaults
           - pull-secret
+          - motd
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}
@@ -50,6 +51,7 @@ jobs:
         instance:
           - defaults
           - pull-secret
+          - motd
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}

--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -50,4 +50,4 @@ KUBENT_IMAGE    ?= ghcr.io/doitintl/kube-no-trouble:latest
 KUBENT_DOCKER   ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) --entrypoint=/app/kubent $(KUBENT_IMAGE)
 
 instance ?= defaults
-test_instances = tests/defaults.yml tests/pull-secret.yml
+test_instances = tests/defaults.yml tests/pull-secret.yml tests/motd.yml

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -9,6 +9,10 @@ parameters:
         registry: docker.io
         repository: bitnami/kubectl
         tag: 1.25.15
+      oc:
+        registry: quay.io
+        repository: appuio/oc
+        tag: v4.16
 
     # Fixes cluster upgrades on OCP4.10 clusters with custom `privileged` SCCs.
     clusterUpgradeSCCPermissionFix:
@@ -17,3 +21,4 @@ parameters:
 
     motd:
       messages: {}
+      include_console_notifications: false

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -14,3 +14,6 @@ parameters:
     clusterUpgradeSCCPermissionFix:
       enabled: true
       priority: 3
+
+    motd:
+      messages: {}

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -32,4 +32,5 @@ local dockercfg = std.trace(
     import 'pull-secret-sync-job.libsonnet',
   [if params.clusterUpgradeSCCPermissionFix.enabled then '02_clusterUpgradeSCCPermissionFix']:
     import 'privileged-scc.libsonnet',
+  [if std.length(params.motd.messages) > 0 then '03_motd']: import 'motd.libsonnet',
 }

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -25,6 +25,8 @@ local dockercfg = std.trace(
   }
 );
 
+local motd = import 'motd.libsonnet';
+
 // Define outputs below
 {
   [if legacyPullSecret != null then '01_dockercfg']: dockercfg,
@@ -32,5 +34,5 @@ local dockercfg = std.trace(
     import 'pull-secret-sync-job.libsonnet',
   [if params.clusterUpgradeSCCPermissionFix.enabled then '02_clusterUpgradeSCCPermissionFix']:
     import 'privileged-scc.libsonnet',
-  [if std.length(params.motd.messages) > 0 then '03_motd']: import 'motd.libsonnet',
+  [if std.length(motd) > 0 then '03_motd']: motd,
 }

--- a/component/motd.libsonnet
+++ b/component/motd.libsonnet
@@ -17,4 +17,102 @@ local motdCM = kube.ConfigMap('motd') {
   },
 };
 
-[ motdCM ]
+local motdTemplate = kube.ConfigMap('motd-template') {
+  metadata+: {
+    namespace: 'openshift',
+  },
+  data: {
+    message: message,
+  },
+};
+
+local namespace = {
+  metadata+: {
+    namespace: 'openshift-config',
+  },
+};
+
+local motdRBAC =
+  local argocd_sa = kube.ServiceAccount('motd-manager') + namespace;
+  local cluster_role = kube.ClusterRole('appuio:motd-editor') {
+    rules: [
+      {
+        apiGroups: [ 'console.openshift.io' ],
+        resources: [ 'consolenotifications' ],
+        verbs: [ 'get', 'list' ],
+      },
+      {
+        apiGroups: [ '' ],
+        resources: [ 'configmaps' ],
+        resourceNames: [ 'motd', 'motd-template' ],
+        verbs: [ '*' ],
+      },
+    ],
+  };
+  local cluster_role_binding =
+    kube.ClusterRoleBinding('appuio:motd-manager') {
+      subjects_: [ argocd_sa ],
+      roleRef_: cluster_role,
+    };
+  {
+    argocd_sa: argocd_sa,
+    cluster_role: cluster_role,
+    cluster_role_binding: cluster_role_binding,
+  };
+
+local motdSync = kube.Job('sync-motd') + namespace {
+  metadata+: {
+    annotations+: {
+      'argocd.argoproj.io/hook': 'PostSync',
+      'argocd.argoproj.io/hook-delete-policy': 'BeforeHookCreation',
+    },
+  },
+  spec+: {
+    template+: {
+      spec+: {
+        containers_+: {
+          notification: kube.Container('sync-motd') {
+            image: '%(registry)s/%(repository)s:%(tag)s' % params.images.oc,
+            name: 'syn-motd',
+            workingDir: '/export',
+            command: [ '/scripts/motd_gen.sh' ],
+            volumeMounts_+: {
+              export: {
+                mountPath: '/export',
+              },
+              scripts: {
+                mountPath: '/scripts',
+              },
+            },
+          },
+        },
+        volumes_+: {
+          export: {
+            emptyDir: {},
+          },
+          scripts: {
+            configMap: {
+              name: 'motd-gen',
+              defaultMode: std.parseOctal('0550'),
+            },
+          },
+        },
+        serviceAccountName: motdRBAC.argocd_sa.metadata.name,
+      },
+    },
+  },
+};
+
+local motdScript = kube.ConfigMap('motd-gen') + namespace {
+  data: {
+    'motd_gen.sh': (importstr 'scripts/motd_gen.sh'),
+  },
+};
+
+if params.motd.include_console_notifications then
+  [ motdTemplate, motdSync, motdScript ] + std.objectValues(motdRBAC)
+else
+  if std.length(params.motd.messages) > 0 then
+    [ motdCM ]
+  else
+    []

--- a/component/motd.libsonnet
+++ b/component/motd.libsonnet
@@ -70,6 +70,9 @@ local jobSpec = {
             name: 'sync-motd',
             workingDir: '/export',
             command: [ '/scripts/motd_gen.sh' ],
+            env_+: {
+              HOME: '/export',
+            },
             volumeMounts_+: {
               export: {
                 mountPath: '/export',

--- a/component/motd.libsonnet
+++ b/component/motd.libsonnet
@@ -1,0 +1,20 @@
+local com = import 'lib/commodore.libjsonnet';
+local kap = import 'lib/kapitan.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+
+local inv = kap.inventory();
+local params = inv.parameters.openshift4_config;
+
+local messages = std.prune([ params.motd.messages[m] for m in std.objectFields(params.motd.messages) ]);
+local message = std.join('\n\n', messages);
+
+local motdCM = kube.ConfigMap('motd') {
+  metadata+: {
+    namespace: 'openshift',
+  },
+  data: {
+    message: message,
+  },
+};
+
+[ motdCM ]

--- a/component/scripts/motd_gen.sh
+++ b/component/scripts/motd_gen.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -exo pipefail
+
+jq 'del(.metadata) | .metadata.name = "motd" | .metadata.labels.name = "motd" | .data.message = ([.data.message] + input | join("\n\n"))' \
+    <(kubectl -n openshift get cm motd-template -ojson) \
+    <(kubectl get consolenotifications -l appuio.io/notification=true -ojson | jq '[.items[].spec.text]') \
+    > /tmp/motd.yaml
+
+if [ -z "$(jq -r '.data.message' /tmp/motd.yaml)" ]; then
+    kubectl -n openshift delete cm -l name=motd
+else
+    kubectl -n openshift apply -f /tmp/motd.yaml
+fi

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -76,3 +76,29 @@ type:: number
 default:: `3`
 
 The priority the resulting SCC will have.
+
+
+== `motd`
+
+[horizontal]
+type:: dictionary
+
+Configure OpenShift's message of the day which is displayed in the terminal when using `oc login`.
+
+=== `motd.messages`
+
+[horizontal]
+type:: dictionary
+default:: `{}`
+
+A dictionary of messages to be displayed in the message of the day.
+Entries with `null` values are skipped.
+This allows users to remove notifications which were configured higher up in the hierarchy.
+
+=== `motd.include_console_notifications`
+
+[horizontal]
+type:: boolean
+default:: `false`
+
+Whether to include the console notifications from https://github.com/appuio/component-openshift4-console/blob/master/docs/modules/ROOT/pages/references/parameters.adoc#notifications[component-openshift4-console] in the message of the day.

--- a/tests/golden/motd/openshift4-config/openshift4-config/02_clusterUpgradeSCCPermissionFix.yaml
+++ b/tests/golden/motd/openshift4-config/openshift4-config/02_clusterUpgradeSCCPermissionFix.yaml
@@ -1,0 +1,48 @@
+allowHostDirVolumePlugin: true
+allowHostIPC: true
+allowHostNetwork: true
+allowHostPID: true
+allowHostPorts: true
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: true
+allowedCapabilities:
+  - '*'
+allowedUnsafeSysctls:
+  - '*'
+apiVersion: security.openshift.io/v1
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups:
+  - system:cluster-admins
+  - system:nodes
+  - system:masters
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: |
+      Copy of `privileged` with increased priority to be choosen over other custom SCCs.
+
+      privileged allows access to all privileged and host features and the ability to run as any user, any group, any fsGroup, and with any SELinux context.
+      WARNING: this is the most relaxed SCC and should be used only for cluster administration. Grant with caution.
+  labels:
+    app.kubernetes.io/component: openshift4-config
+    app.kubernetes.io/managed-by: commodore
+    name: privileged-higher-prio
+  name: privileged-higher-prio
+priority: 3
+readOnlyRootFilesystem: false
+requiredDropCapabilities: null
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+seccompProfiles:
+  - '*'
+supplementalGroups:
+  type: RunAsAny
+users:
+  - system:admin
+  - system:serviceaccount:openshift-infra:build-controller
+volumes:
+  - '*'

--- a/tests/golden/motd/openshift4-config/openshift4-config/03_motd.yaml
+++ b/tests/golden/motd/openshift4-config/openshift4-config/03_motd.yaml
@@ -37,7 +37,7 @@ spec:
           env: []
           image: quay.io/appuio/oc:v4.16
           imagePullPolicy: IfNotPresent
-          name: syn-motd
+          name: sync-motd
           ports: []
           stdin: false
           tty: false
@@ -83,6 +83,58 @@ metadata:
     name: motd-gen
   name: motd-gen
   namespace: openshift-config
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  annotations: {}
+  labels:
+    name: sync-motd
+  name: sync-motd
+  namespace: openshift-config
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      completions: 1
+      parallelism: 1
+      template:
+        metadata:
+          labels:
+            name: sync-motd
+        spec:
+          containers:
+            - args: []
+              command:
+                - /scripts/motd_gen.sh
+              env: []
+              image: quay.io/appuio/oc:v4.16
+              imagePullPolicy: IfNotPresent
+              name: sync-motd
+              ports: []
+              stdin: false
+              tty: false
+              volumeMounts:
+                - mountPath: /export
+                  name: export
+                - mountPath: /scripts
+                  name: scripts
+              workingDir: /export
+          imagePullSecrets: []
+          initContainers: []
+          restartPolicy: OnFailure
+          serviceAccountName: motd-manager
+          terminationGracePeriodSeconds: 30
+          volumes:
+            - emptyDir: {}
+              name: export
+            - configMap:
+                defaultMode: 360
+                name: motd-gen
+              name: scripts
+  schedule: 27 */4 * * *
+  successfulJobsHistoryLimit: 10
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/tests/golden/motd/openshift4-config/openshift4-config/03_motd.yaml
+++ b/tests/golden/motd/openshift4-config/openshift4-config/03_motd.yaml
@@ -34,7 +34,9 @@ spec:
         - args: []
           command:
             - /scripts/motd_gen.sh
-          env: []
+          env:
+            - name: HOME
+              value: /export
           image: quay.io/appuio/oc:v4.16
           imagePullPolicy: IfNotPresent
           name: sync-motd
@@ -108,7 +110,9 @@ spec:
             - args: []
               command:
                 - /scripts/motd_gen.sh
-              env: []
+              env:
+                - name: HOME
+                  value: /export
               image: quay.io/appuio/oc:v4.16
               imagePullPolicy: IfNotPresent
               name: sync-motd

--- a/tests/golden/motd/openshift4-config/openshift4-config/03_motd.yaml
+++ b/tests/golden/motd/openshift4-config/openshift4-config/03_motd.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+data:
+  message: |-
+    Welcome to APPUiO
+
+    This cluster will soon be upgraded.
+kind: ConfigMap
+metadata:
+  annotations: {}
+  labels:
+    name: motd
+  name: motd
+  namespace: openshift

--- a/tests/golden/motd/openshift4-config/openshift4-config/03_motd.yaml
+++ b/tests/golden/motd/openshift4-config/openshift4-config/03_motd.yaml
@@ -8,6 +8,128 @@ kind: ConfigMap
 metadata:
   annotations: {}
   labels:
-    name: motd
-  name: motd
+    name: motd-template
+  name: motd-template
   namespace: openshift
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+  labels:
+    name: sync-motd
+  name: sync-motd
+  namespace: openshift-config
+spec:
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        name: sync-motd
+    spec:
+      containers:
+        - args: []
+          command:
+            - /scripts/motd_gen.sh
+          env: []
+          image: quay.io/appuio/oc:v4.16
+          imagePullPolicy: IfNotPresent
+          name: syn-motd
+          ports: []
+          stdin: false
+          tty: false
+          volumeMounts:
+            - mountPath: /export
+              name: export
+            - mountPath: /scripts
+              name: scripts
+          workingDir: /export
+      imagePullSecrets: []
+      initContainers: []
+      restartPolicy: OnFailure
+      serviceAccountName: motd-manager
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - emptyDir: {}
+          name: export
+        - configMap:
+            defaultMode: 360
+            name: motd-gen
+          name: scripts
+---
+apiVersion: v1
+data:
+  motd_gen.sh: |
+    #!/bin/bash
+    set -exo pipefail
+
+    jq 'del(.metadata) | .metadata.name = "motd" | .metadata.labels.name = "motd" | .data.message = ([.data.message] + input | join("\n\n"))' \
+        <(kubectl -n openshift get cm motd-template -ojson) \
+        <(kubectl get consolenotifications -l appuio.io/notification=true -ojson | jq '[.items[].spec.text]') \
+        > /tmp/motd.yaml
+
+    if [ -z "$(jq -r '.data.message' /tmp/motd.yaml)" ]; then
+        kubectl -n openshift delete cm -l name=motd
+    else
+        kubectl -n openshift apply -f /tmp/motd.yaml
+    fi
+kind: ConfigMap
+metadata:
+  annotations: {}
+  labels:
+    name: motd-gen
+  name: motd-gen
+  namespace: openshift-config
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    name: motd-manager
+  name: motd-manager
+  namespace: openshift-config
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-motd-editor
+  name: appuio:motd-editor
+rules:
+  - apiGroups:
+      - console.openshift.io
+    resources:
+      - consolenotifications
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - ''
+    resourceNames:
+      - motd
+      - motd-template
+    resources:
+      - configmaps
+    verbs:
+      - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-motd-manager
+  name: appuio:motd-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appuio:motd-editor
+subjects:
+  - kind: ServiceAccount
+    name: motd-manager
+    namespace: openshift-config

--- a/tests/motd.yml
+++ b/tests/motd.yml
@@ -1,0 +1,3 @@
+# Overwrite parameters here
+
+# parameters: {...}

--- a/tests/motd.yml
+++ b/tests/motd.yml
@@ -1,3 +1,7 @@
-# Overwrite parameters here
-
-# parameters: {...}
+parameters:
+  openshift4_config:
+    motd:
+      messages:
+        emtpy_message: null
+        greeting: Welcome to APPUiO
+        upgrade: This cluster will soon be upgraded.

--- a/tests/motd.yml
+++ b/tests/motd.yml
@@ -1,6 +1,7 @@
 parameters:
   openshift4_config:
     motd:
+      include_console_notifications: true
       messages:
         emtpy_message: null
         greeting: Welcome to APPUiO


### PR DESCRIPTION
This is the an extension for the customer notification feature in https://github.com/appuio/component-openshift4-console/pull/74

Arbitrary messages can be displayed with OpenShift's message of the day that's displayed when using `oc login`. Also adds the option to include the message from the console notifications (this includes the automated upgrade notifications).

All messages are concatenated into a single message of the day. The message of the day is updated with an ArgoCD sync job and periodically with a cronjob.
 
## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
