### PR TITLE
Delete motd configmap by name instead of by label

### DIFF
--- a/component/scripts/motd_gen.sh
+++ b/component/scripts/motd_gen.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 set -exo pipefail
 
-jq 'del(.metadata) | .metadata.name = "motd" | .metadata.labels.name = "motd" | .data.message = ([.data.message] + input | join("\n\n"))' \
+jq 'del(.metadata) | .metadata.name = "motd" | .data.message = ([.data.message] + input | join("\n\n"))' \
     <(kubectl -n openshift get cm motd-template -ojson) \
     <(kubectl get consolenotifications -l appuio.io/notification=true -ojson | jq '[.items[].spec.text]') \
     > /tmp/motd.yaml
 
 if [ -z "$(jq -r '.data.message' /tmp/motd.yaml)" ]; then
-    kubectl -n openshift delete cm -l name=motd
+    kubectl -n openshift delete cm motd --ignore-not-found
 else
     kubectl -n openshift apply -f /tmp/motd.yaml
 fi

--- a/tests/golden/motd/openshift4-config/openshift4-config/03_motd.yaml
+++ b/tests/golden/motd/openshift4-config/openshift4-config/03_motd.yaml
@@ -68,13 +68,13 @@ data:
     #!/bin/bash
     set -exo pipefail
 
-    jq 'del(.metadata) | .metadata.name = "motd" | .metadata.labels.name = "motd" | .data.message = ([.data.message] + input | join("\n\n"))' \
+    jq 'del(.metadata) | .metadata.name = "motd" | .data.message = ([.data.message] + input | join("\n\n"))' \
         <(kubectl -n openshift get cm motd-template -ojson) \
         <(kubectl get consolenotifications -l appuio.io/notification=true -ojson | jq '[.items[].spec.text]') \
         > /tmp/motd.yaml
 
     if [ -z "$(jq -r '.data.message' /tmp/motd.yaml)" ]; then
-        kubectl -n openshift delete cm -l name=motd
+        kubectl -n openshift delete cm motd --ignore-not-found
     else
         kubectl -n openshift apply -f /tmp/motd.yaml
     fi


### PR DESCRIPTION
The service account does not have permissions to list all configmaps in the `openshift` namespace.


## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
