### PR TITLE
Fix RBAC to allow motd sync cronjob to create the `motd` configmap

### DIFF
--- a/component/motd.libsonnet
+++ b/component/motd.libsonnet
@@ -33,7 +33,7 @@ local namespace = {
 };
 
 local motdRBAC =
-  local argocd_sa = kube.ServiceAccount('motd-manager') + namespace;
+  local motd_sa = kube.ServiceAccount('motd-manager') + namespace;
   local cluster_role = kube.ClusterRole('appuio:motd-editor') {
     rules: [
       {
@@ -51,11 +51,11 @@ local motdRBAC =
   };
   local cluster_role_binding =
     kube.ClusterRoleBinding('appuio:motd-manager') {
-      subjects_: [ argocd_sa ],
+      subjects_: [ motd_sa ],
       roleRef_: cluster_role,
     };
   {
-    argocd_sa: argocd_sa,
+    motd_sa: motd_sa,
     cluster_role: cluster_role,
     cluster_role_binding: cluster_role_binding,
   };
@@ -94,7 +94,7 @@ local jobSpec = {
             },
           },
         },
-        serviceAccountName: motdRBAC.argocd_sa.metadata.name,
+        serviceAccountName: motdRBAC.motd_sa.metadata.name,
       },
     },
   },

--- a/component/motd.libsonnet
+++ b/component/motd.libsonnet
@@ -41,12 +41,6 @@ local motdRBAC =
         resources: [ 'consolenotifications' ],
         verbs: [ 'get', 'list' ],
       },
-      {
-        apiGroups: [ '' ],
-        resources: [ 'configmaps' ],
-        resourceNames: [ 'motd', 'motd-template' ],
-        verbs: [ '*' ],
-      },
     ],
   };
   local cluster_role_binding =
@@ -54,10 +48,22 @@ local motdRBAC =
       subjects_: [ motd_sa ],
       roleRef_: cluster_role,
     };
+  local role_binding = kube.RoleBinding('appuio:motd-manager') {
+    metadata+: {
+      namespace: 'openshift',
+    },
+    subjects_: [ motd_sa ],
+    roleRef: {
+      apiGroup: 'rbac.authorization.k8s.io',
+      kind: 'ClusterRole',
+      name: 'edit',
+    },
+  };
   {
     motd_sa: motd_sa,
     cluster_role: cluster_role,
     cluster_role_binding: cluster_role_binding,
+    role_binding: role_binding,
   };
 
 local jobSpec = {

--- a/tests/golden/motd/openshift4-config/openshift4-config/03_motd.yaml
+++ b/tests/golden/motd/openshift4-config/openshift4-config/03_motd.yaml
@@ -155,15 +155,6 @@ rules:
     verbs:
       - get
       - list
-  - apiGroups:
-      - ''
-    resourceNames:
-      - motd
-      - motd-template
-    resources:
-      - configmaps
-    verbs:
-      - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -189,3 +180,20 @@ metadata:
     name: motd-manager
   name: motd-manager
   namespace: openshift-config
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-motd-manager
+  name: appuio:motd-manager
+  namespace: openshift
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: edit
+subjects:
+  - kind: ServiceAccount
+    name: motd-manager
+    namespace: openshift-config

--- a/tests/golden/motd/openshift4-config/openshift4-config/03_motd.yaml
+++ b/tests/golden/motd/openshift4-config/openshift4-config/03_motd.yaml
@@ -140,15 +140,6 @@ spec:
   schedule: 27 */4 * * *
   successfulJobsHistoryLimit: 10
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  annotations: {}
-  labels:
-    name: motd-manager
-  name: motd-manager
-  namespace: openshift-config
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -189,3 +180,12 @@ subjects:
   - kind: ServiceAccount
     name: motd-manager
     namespace: openshift-config
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    name: motd-manager
+  name: motd-manager
+  namespace: openshift-config


### PR DESCRIPTION
We can't restrict `create` to resource names, so we simply give the motd-sync service account `edit` permissions in the `openshift`
namespace.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
