### PR TITLE
Aggregate `get/list/watch` for all `operator.openshift.io` resources to `cluster-reader`

### DIFF
--- a/component/aggregated-clusterroles.libsonnet
+++ b/component/aggregated-clusterroles.libsonnet
@@ -1,0 +1,29 @@
+local kube = import 'lib/kube.libjsonnet';
+
+local operator_openshift_io_cluster_reader =
+  kube.ClusterRole('syn:aggregate-operator-openshift-io-to-cluster-reader') {
+    metadata+: {
+      labels+: {
+        'rbac.authorization.k8s.io/aggregate-to-cluster-reader': 'true',
+      },
+    },
+    rules: [
+      {
+        apiGroups: [
+          'operator.openshift.io',
+        ],
+        resources: [
+          '*',
+        ],
+        verbs: [
+          'get',
+          'list',
+          'watch',
+        ],
+      },
+    ],
+  };
+
+[
+  operator_openshift_io_cluster_reader,
+]

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -35,4 +35,5 @@ local motd = import 'motd.libsonnet';
   [if params.clusterUpgradeSCCPermissionFix.enabled then '02_clusterUpgradeSCCPermissionFix']:
     import 'privileged-scc.libsonnet',
   [if std.length(motd) > 0 then '03_motd']: motd,
+  '10_aggregate_to_cluster_reaqder': import 'aggregated-clusterroles.libsonnet',
 }

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -4,4 +4,7 @@ openshift4-config is a Commodore component to manage openshift4-config.
 
 Currently, this component can manage the global cluster pull secret as described in the https://docs.openshift.com/container-platform/latest/openshift_images/managing_images/using-image-pull-secrets.html#images-update-global-pull-secret_using-image-pull-secret[OpenShift documentation].
 
+Additionally, the component deploys custom `ClusterRole` resources which are aggregated to the `cluster-reader` cluster role.
+Currently, the component aggregates `get/list/watch` permissions for all `operator.openshift.io` resources to the `cluster-reader` role.
+
 See the xref:references/parameters.adoc[parameters] reference for further details.

--- a/tests/golden/defaults/openshift4-config/openshift4-config/10_aggregate_to_cluster_reaqder.yaml
+++ b/tests/golden/defaults/openshift4-config/openshift4-config/10_aggregate_to_cluster_reaqder.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-aggregate-operator-openshift-io-to-cluster-reader
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
+  name: syn:aggregate-operator-openshift-io-to-cluster-reader
+rules:
+  - apiGroups:
+      - operator.openshift.io
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch

--- a/tests/golden/motd/openshift4-config/openshift4-config/10_aggregate_to_cluster_reaqder.yaml
+++ b/tests/golden/motd/openshift4-config/openshift4-config/10_aggregate_to_cluster_reaqder.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-aggregate-operator-openshift-io-to-cluster-reader
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
+  name: syn:aggregate-operator-openshift-io-to-cluster-reader
+rules:
+  - apiGroups:
+      - operator.openshift.io
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch

--- a/tests/golden/pull-secret/openshift4-config/openshift4-config/10_aggregate_to_cluster_reaqder.yaml
+++ b/tests/golden/pull-secret/openshift4-config/openshift4-config/10_aggregate_to_cluster_reaqder.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-aggregate-operator-openshift-io-to-cluster-reader
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
+  name: syn:aggregate-operator-openshift-io-to-cluster-reader
+rules:
+  - apiGroups:
+      - operator.openshift.io
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch


### PR DESCRIPTION
This will make our lives easier when working with cluster-operator configs (e.g. node disruption policies, cluster networking, ...)




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.


<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
