### PR TITLE
Add support for managing `etcd.operator.openshift.io/cluster`

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -7,7 +7,7 @@
       "name": "openshift4-config",
       "slug": "openshift4-config",
       "parameter_key": "openshift4_config",
-      "test_cases": "defaults pull-secret motd",
+      "test_cases": "defaults pull-secret motd etcd",
       "add_lib": "n",
       "add_pp": "n",
       "add_golden": "y",
@@ -24,7 +24,8 @@
       "github_owner": "appuio",
       "github_name": "component-openshift4-config",
       "github_url": "https://github.com/appuio/component-openshift4-config",
-      "_template": "https://github.com/projectsyn/commodore-component-template.git"
+      "_template": "https://github.com/projectsyn/commodore-component-template.git",
+      "_commit": "98d16f99766e6c6d97322dbe42e058f0e2bf73d0"
     }
   },
   "directory": null

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,6 +35,7 @@ jobs:
           - defaults
           - pull-secret
           - motd
+          - etcd
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}
@@ -52,6 +53,7 @@ jobs:
           - defaults
           - pull-secret
           - motd
+          - etcd
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}

--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -50,4 +50,4 @@ KUBENT_IMAGE    ?= ghcr.io/doitintl/kube-no-trouble:latest
 KUBENT_DOCKER   ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) --entrypoint=/app/kubent $(KUBENT_IMAGE)
 
 instance ?= defaults
-test_instances = tests/defaults.yml tests/pull-secret.yml tests/motd.yml
+test_instances = tests/defaults.yml tests/pull-secret.yml tests/motd.yml tests/etcd.yml

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -18,7 +18,7 @@ parameters:
       messages: {}
       include_console_notifications: false
 
-    etcd:
+    etcdCustomization:
       enabled: false
       spec:
         controlPlaneHardwareSpeed: ""

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -17,3 +17,8 @@ parameters:
     motd:
       messages: {}
       include_console_notifications: false
+
+    etcd:
+      enabled: false
+      spec:
+        controlPlaneHardwareSpeed: ""

--- a/component/espejote-templates/etcd-helpers.libsonnet
+++ b/component/espejote-templates/etcd-helpers.libsonnet
@@ -1,0 +1,22 @@
+local apiGroup = 'operator.openshift.io';
+local apiVersion = '%s/v1' % apiGroup;
+local kind = 'Etcd';
+local resource = 'etcds';
+local resourceName = 'cluster';
+
+local etcd = {
+  apiVersion: apiVersion,
+  kind: kind,
+  metadata: {
+    name: resourceName,
+  },
+};
+
+{
+  apiGroup: apiGroup,
+  apiVersion: apiVersion,
+  kind: kind,
+  resource: resource,
+  resourceName: resourceName,
+  Etcd: etcd,
+}

--- a/component/espejote-templates/manage-etcd.jsonnet
+++ b/component/espejote-templates/manage-etcd.jsonnet
@@ -1,0 +1,8 @@
+local esp = import 'espejote.libsonnet';
+
+local etcd = import 'appuio-etcd/etcd.libsonnet';
+local spec = import 'appuio-etcd/spec.json';
+
+etcd.Etcd {
+  spec: spec,
+}

--- a/component/etcd.libsonnet
+++ b/component/etcd.libsonnet
@@ -39,7 +39,7 @@ local jl = esp.jsonnetLibrary('appuio-etcd', namespace) {
   },
   spec: {
     data: {
-      'spec.json': std.manifestJson(params.etcd.spec),
+      'spec.json': std.manifestJson(params.etcdCustomization.spec),
       'etcd.libsonnet': importstr 'espejote-templates/etcd-helpers.libsonnet',
     },
   },

--- a/component/etcd.libsonnet
+++ b/component/etcd.libsonnet
@@ -47,6 +47,9 @@ local jl = esp.jsonnetLibrary('appuio-etcd', namespace) {
 
 local mr = esp.managedResource('appuio-etcd', namespace) {
   spec: {
+    // Set force=true so we can take ownership of previously manually edited
+    // fields in `spec`.
+    applyOptions: { force: true },
     serviceAccountRef: { name: sa.metadata.name },
     triggers: [
       {

--- a/component/etcd.libsonnet
+++ b/component/etcd.libsonnet
@@ -1,0 +1,65 @@
+local kap = import 'lib/kapitan.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+
+local inv = kap.inventory();
+local params = inv.parameters.openshift4_config;
+
+local esp = import 'lib/espejote.libsonnet';
+
+local namespace = 'openshift-config';
+
+local sa = kube.ServiceAccount('appuio-etcd-manager') {
+  metadata+: {
+    namespace: namespace,
+  },
+};
+
+local etcd = import 'espejote-templates/etcd-helpers.libsonnet';
+
+local clusterrole = kube.ClusterRole('appuio:openshift4-config:etcd-manager') {
+  rules: [
+    {
+      apiGroups: [ etcd.apiGroup ],
+      resources: [ etcd.resource ],
+      resourceNames: [ etcd.resourceName ],
+      verbs: [ 'get', 'list', 'watch', 'patch' ],
+    },
+  ],
+};
+
+local clusterrolebinding =
+  kube.ClusterRoleBinding('appuio:openshift4-config:etcd-manager') {
+    roleRef_: clusterrole,
+    subjects_: [ sa ],
+  };
+
+local jl = esp.jsonnetLibrary('appuio-etcd', namespace) {
+  metadata+: {
+    namespace: 'openshift-config',
+  },
+  spec: {
+    data: {
+      'spec.json': std.manifestJson(params.etcd.spec),
+      'etcd.libsonnet': importstr 'espejote-templates/etcd-helpers.libsonnet',
+    },
+  },
+};
+
+local mr = esp.managedResource('appuio-etcd', namespace) {
+  spec: {
+    serviceAccountRef: { name: sa.metadata.name },
+    triggers: [
+      {
+        name: 'etcd',
+        watchResource: {
+          apiVersion: etcd.apiVersion,
+          kind: etcd.kind,
+          name: etcd.resourceName,
+        },
+      },
+    ],
+    template: importstr 'espejote-templates/manage-etcd.jsonnet',
+  },
+};
+
+[ sa, clusterrole, clusterrolebinding, jl, mr ]

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -34,6 +34,6 @@ local motd = import 'motd.libsonnet';
   [if legacyPullSecret == null && std.length(std.objectFields(params.globalPullSecrets)) > 0 then '99_cluster_pull_secret']:
     import 'pull-secret-sync-job.libsonnet',
   [if std.length(motd) > 0 then '03_motd']: motd,
-  [if params.etcd.enabled then '05_etcd_managedresource']: import 'etcd.libsonnet',
+  [if params.etcdCustomization.enabled then '05_etcd_managedresource']: import 'etcd.libsonnet',
   '10_aggregate_to_cluster_reader': import 'aggregated-clusterroles.libsonnet',
 }

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -27,11 +27,13 @@ local dockercfg = std.trace(
 
 local motd = import 'motd.libsonnet';
 
+
 // Define outputs below
 {
   [if legacyPullSecret != null then '01_dockercfg']: dockercfg,
   [if legacyPullSecret == null && std.length(std.objectFields(params.globalPullSecrets)) > 0 then '99_cluster_pull_secret']:
     import 'pull-secret-sync-job.libsonnet',
   [if std.length(motd) > 0 then '03_motd']: motd,
+  [if params.etcd.enabled then '05_etcd_managedresource']: import 'etcd.libsonnet',
   '10_aggregate_to_cluster_reader': import 'aggregated-clusterroles.libsonnet',
 }

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -88,24 +88,24 @@ The component will include each console notification's `spec.text` and `spec.lin
 
 For console notifications which don't provide `spec.link`, the second line will be omitted.
 
-== `etcd`
+== `etcdCustomziation`
 
 [horizontal]
 type:: dictionary
 
-This parameter allows configuring the cluster's etcd.
+This parameter allows customizing the cluster's etcd.
 The implementation uses https://github.com/vshn/espejote[Espejote] to reconcile our customizations for the `etcd.operator.openshift.io/cluster` resource.
 
-=== `etcd.enabled`
+=== `etcdCustomization.enabled`
 
 [horizontal]
-type:: booloean
+type:: boolean
 default:: `false`
 
 Whether to deploy the Espejote managed resource on the cluster.
 If this parameter is set to `false`, changing the contents of `etcd.spec` has no effect.
 
-== `etcd.spec`
+=== `etcdCustomization.spec`
 
 [horizontal]
 type:: dictionary

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -87,3 +87,29 @@ The component will include each console notification's `spec.text` and `spec.lin
 ----
 
 For console notifications which don't provide `spec.link`, the second line will be omitted.
+
+== `etcd`
+
+[horizontal]
+type:: dictionary
+
+This parameter allows configuring the cluster's etcd.
+The implementation uses https://github.com/vshn/espejote[Espejote] to reconcile our customizations for the `etcd.operator.openshift.io/cluster` resource.
+
+=== `etcd.enabled`
+
+[horizontal]
+type:: booloean
+default:: `false`
+
+Whether to deploy the Espejote managed resource on the cluster.
+If this parameter is set to `false`, changing the contents of `etcd.spec` has no effect.
+
+== `etcd.spec`
+
+[horizontal]
+type:: dictionary
+default:: https://github.com/appuio/component-openshift4-config/blob/master/class/defaults.yml[See `class/defaults.yml`]
+
+A partial `spec` for the OpenShift 4 `Etcd` custom resource.
+See the https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/operator_apis/etcd-operator-openshift-io-v1#spec-11[upstream API documentation] for available fields.

--- a/tests/etcd.yml
+++ b/tests/etcd.yml
@@ -6,5 +6,5 @@ parameters:
         output_path: vendor/lib/espejote.libsonnet
 
   openshift4_config:
-    etcd:
+    etcdCustomization:
       enabled: true

--- a/tests/etcd.yml
+++ b/tests/etcd.yml
@@ -1,0 +1,10 @@
+parameters:
+  kapitan:
+    dependencies:
+      - type: https
+        source: https://raw.githubusercontent.com/projectsyn/component-espejote/v0.5.0/lib/espejote.libsonnet
+        output_path: vendor/lib/espejote.libsonnet
+
+  openshift4_config:
+    etcd:
+      enabled: true

--- a/tests/golden/etcd/openshift4-config/openshift4-config/05_etcd_managedresource.yaml
+++ b/tests/golden/etcd/openshift4-config/openshift4-config/05_etcd_managedresource.yaml
@@ -1,0 +1,107 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-etcd-manager
+  name: appuio-etcd-manager
+  namespace: openshift-config
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-openshift4-config-etcd-manager
+  name: appuio:openshift4-config:etcd-manager
+rules:
+  - apiGroups:
+      - operator.openshift.io
+    resourceNames:
+      - cluster
+    resources:
+      - etcds
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-openshift4-config-etcd-manager
+  name: appuio:openshift4-config:etcd-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appuio:openshift4-config:etcd-manager
+subjects:
+  - kind: ServiceAccount
+    name: appuio-etcd-manager
+    namespace: openshift-config
+---
+apiVersion: espejote.io/v1alpha1
+kind: JsonnetLibrary
+metadata:
+  labels:
+    app.kubernetes.io/name: appuio-etcd
+  name: appuio-etcd
+  namespace: openshift-config
+spec:
+  data:
+    etcd.libsonnet: |
+      local apiGroup = 'operator.openshift.io';
+      local apiVersion = '%s/v1' % apiGroup;
+      local kind = 'Etcd';
+      local resource = 'etcds';
+      local resourceName = 'cluster';
+
+      local etcd = {
+        apiVersion: apiVersion,
+        kind: kind,
+        metadata: {
+          name: resourceName,
+        },
+      };
+
+      {
+        apiGroup: apiGroup,
+        apiVersion: apiVersion,
+        kind: kind,
+        resource: resource,
+        resourceName: resourceName,
+        Etcd: etcd,
+      }
+    spec.json: |-
+      {
+          "controlPlaneHardwareSpeed": ""
+      }
+---
+apiVersion: espejote.io/v1alpha1
+kind: ManagedResource
+metadata:
+  labels:
+    app.kubernetes.io/name: appuio-etcd
+  name: appuio-etcd
+  namespace: openshift-config
+spec:
+  serviceAccountRef:
+    name: appuio-etcd-manager
+  template: |
+    local esp = import 'espejote.libsonnet';
+
+    local etcd = import 'appuio-etcd/etcd.libsonnet';
+    local spec = import 'appuio-etcd/spec.json';
+
+    etcd.Etcd {
+      spec: spec,
+    }
+  triggers:
+    - name: etcd
+      watchResource:
+        apiVersion: operator.openshift.io/v1
+        kind: Etcd
+        name: cluster

--- a/tests/golden/etcd/openshift4-config/openshift4-config/05_etcd_managedresource.yaml
+++ b/tests/golden/etcd/openshift4-config/openshift4-config/05_etcd_managedresource.yaml
@@ -88,6 +88,8 @@ metadata:
   name: appuio-etcd
   namespace: openshift-config
 spec:
+  applyOptions:
+    force: true
   serviceAccountRef:
     name: appuio-etcd-manager
   template: |

--- a/tests/golden/etcd/openshift4-config/openshift4-config/10_aggregate_to_cluster_reader.yaml
+++ b/tests/golden/etcd/openshift4-config/openshift4-config/10_aggregate_to_cluster_reader.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-aggregate-operator-openshift-io-to-cluster-reader
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
+  name: syn:aggregate-operator-openshift-io-to-cluster-reader
+rules:
+  - apiGroups:
+      - operator.openshift.io
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch


### PR DESCRIPTION
This PR introduces an Espejote managed resource which reconciles the `etcd.operator.openshift.io/cluster` resource. Users can provide a partial valid `spec` for the resource via component parameter `etcd.spec`.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
