### PR TITLE
Add Espejote ManagedResource which configures the `vsphere-creds` secret

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,13 +1,13 @@
 {
   "template": "https://github.com/projectsyn/commodore-component-template.git",
-  "commit": "5ae57721558399419f867334e31d23a7f7a892ba",
+  "commit": "fa60b771b1f456194b0249c80061c7eb5980850e",
   "checkout": "main",
   "context": {
     "cookiecutter": {
       "name": "openshift4-config",
       "slug": "openshift4-config",
       "parameter_key": "openshift4_config",
-      "test_cases": "defaults pull-secret motd etcd",
+      "test_cases": "defaults pull-secret motd etcd vsphere",
       "add_lib": "n",
       "add_pp": "n",
       "add_golden": "y",
@@ -25,7 +25,7 @@
       "github_name": "component-openshift4-config",
       "github_url": "https://github.com/appuio/component-openshift4-config",
       "_template": "https://github.com/projectsyn/commodore-component-template.git",
-      "_commit": "5ae57721558399419f867334e31d23a7f7a892ba"
+      "_commit": "fa60b771b1f456194b0249c80061c7eb5980850e"
     }
   },
   "directory": null

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,6 +36,7 @@ jobs:
           - pull-secret
           - motd
           - etcd
+          - vsphere
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}
@@ -54,6 +55,7 @@ jobs:
           - pull-secret
           - motd
           - etcd
+          - vsphere
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}

--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -50,4 +50,4 @@ KUBENT_IMAGE    ?= ghcr.io/doitintl/kube-no-trouble:latest
 KUBENT_DOCKER   ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) --entrypoint=/app/kubent $(KUBENT_IMAGE)
 
 instance ?= defaults
-test_instances = tests/defaults.yml tests/pull-secret.yml tests/motd.yml tests/etcd.yml
+test_instances = tests/defaults.yml tests/pull-secret.yml tests/motd.yml tests/etcd.yml tests/vsphere.yml

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -4,6 +4,12 @@ parameters:
       multi_tenant: true
     globalPullSecrets: {}
     caBundle: null
+    cloud: null
+
+    vsphere:
+      vcenterURL: null
+      username: null
+      password: null
 
     images:
       oc:

--- a/component/espejote-templates/vsphere-creds.jsonnet
+++ b/component/espejote-templates/vsphere-creds.jsonnet
@@ -1,0 +1,22 @@
+local esp = import 'espejote.libsonnet';
+
+local source = esp.context().source;
+assert
+  std.length(source) == 1
+  : 'Expected source context to have exactly 1 element';
+assert
+  source[0].kind == 'Secret'
+  : 'Expected source to be a `Secret`, is a `%s`' % source[0].kind;
+
+{
+  apiVersion: 'v1',
+  kind: 'Secret',
+  metadata: {
+    name: 'vsphere-creds',
+    namespace: 'kube-system',
+    annotations: {
+      'espejote.io/managed-by': 'openshift-config/vsphere-credentials',
+    },
+  },
+  data: source[0].data,
+}

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -51,6 +51,8 @@ local caBundle = {
   },
 };
 
+local vsphere = import 'vsphere.libsonnet';
+
 
 // Define outputs below
 {
@@ -61,4 +63,8 @@ local caBundle = {
   [if params.etcdCustomization.enabled then '05_etcd_managedresource']: import 'etcd.libsonnet',
   '10_aggregate_to_cluster_reader': import 'aggregated-clusterroles.libsonnet',
   [if params.caBundle != null then '11_ca_bundle']: caBundle,
-}
+} + if params.cloud == 'vsphere' then {
+  ['20_vsphere_%s' % manifest]: vsphere[manifest]
+  for manifest in std.objectFields(vsphere)
+  if vsphere[manifest] != null
+} else {}

--- a/component/vsphere.libsonnet
+++ b/component/vsphere.libsonnet
@@ -1,0 +1,101 @@
+local esp = import 'lib/espejote.libsonnet';
+local kap = import 'lib/kapitan.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+
+local inv = kap.inventory();
+local params = inv.parameters.openshift4_config;
+
+local name = 'vsphere-credentials-manager';
+
+
+local sa = kube.ServiceAccount(name) {
+  metadata+: {
+    namespace: 'openshift-config',
+  },
+};
+
+local role = kube.Role(name) {
+  metadata+: {
+    namespace: 'kube-system',
+  },
+  rules: [ {
+    apiGroups: [ '' ],
+    resources: [ 'secrets' ],
+    resourceNames: [ 'vsphere-creds' ],
+    verbs: [ 'get', 'list', 'watch', 'update', 'patch' ],
+  } ],
+};
+
+local rolebinding = kube.RoleBinding(name) {
+  metadata+: {
+    namespace: 'kube-system',
+  },
+  roleRef_: role,
+  subjects_: [ sa ],
+};
+
+local secret =
+  local vsphereConfig = params.vsphere;
+  assert
+    vsphereConfig.vcenterURL != null
+    : '`params.vsphere.vcenterURL` must be set when `params.cloud==vsphere`';
+  assert
+    vsphereConfig.username != null
+    : '`params.vsphere.username` must be set when `params.cloud==vsphere`';
+  assert
+    vsphereConfig.password != null
+    : '`params.vsphere.password` must be set when `params.cloud==vsphere`';
+  kube.Secret('appuio-vsphere-creds') {
+    metadata+: {
+      namespace: 'openshift-config',
+    },
+    stringData: {
+      ['%s.username' % vsphereConfig.vcenterURL]: vsphereConfig.username,
+      ['%s.password' % vsphereConfig.vcenterURL]: vsphereConfig.password,
+    },
+  };
+
+local credentialsMr =
+  esp.managedResource('vsphere-credentials', 'openshift-config') {
+    spec+: {
+      applyOptions: {
+        force: true,
+      },
+      serviceAccountRef: {
+        name: sa.metadata.name,
+      },
+      context: [
+        {
+          name: 'source',
+          resource: {
+            apiVersion: secret.apiVersion,
+            kind: secret.kind,
+            namespace: secret.metadata.namespace,
+            name: secret.metadata.name,
+          },
+        },
+      ],
+      triggers: [
+        {
+          name: 'vsphere-creds',
+          watchResource: {
+            apiVersion: 'v1',
+            name: 'vsphere-creds',
+            kind: 'Secret',
+            namespace: 'kube-system',
+          },
+        },
+        {
+          name: 'source',
+          watchContextResource: {
+            name: 'source',
+          },
+        },
+      ],
+      template: importstr 'espejote-templates/vsphere-creds.jsonnet',
+    },
+  };
+
+{
+  credentials: [ credentialsMr, secret, sa, role, rolebinding ],
+}

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -10,4 +10,6 @@ Currently, the component aggregates `get/list/watch` permissions for the followi
 * `operator.openshift.io`
 * `networking.k8s.io`
 
+On vSphere, the component also supports managing the cluster's vSphere credentials (secret `vsphere-creds` in namespace `kube-system`).
+
 See the xref:references/parameters.adoc[parameters] reference for further details.

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -79,6 +79,33 @@ OpenShift uses a separate config map called `user-ca-bundle` in namespace `opens
 See parameter `trustedCA` in component https://hub.syn.tools/openshift4-proxy/references/parameters.html#_trustedca[openshift4-proxy] for details on how to deploy additional trusted CA certificates for the system-wide trusted CA bundle.
 ====
 
+== `cloud`
+
+[horizontal]
+type:: string
+default:: `null`
+
+The cloud provider on which the cluster is running.
+Currently, the component only looks at this parameter to check whether to manage vSphere credentials, see also parameter <<_vsphere,`vsphere`>>.
+
+== `vsphere`
+
+[horizontal]
+type:: dictionary
+default:: `{"vcenterURL": null, "username": null, "password": null}`
+
+The vSphere credentials for the cluster.
+
+If parameter <<_cloud,`cloud`>> is `vsphere`, the component verifies that none of the fields are `null` and deploys a secret `appuio-vsphere-creds` in namespace `openshift-config`.
+The contents of that secret are preformatted to work as contents for secret `vsphere-creds` in namespace `kube-system`.
+The component needs the vCenter URL because the secret fields must be named `<vcenter-url>.username` and `<vcenter-url>.password`.
+In addition to the secret the component also deploys an Espejote `ManagedResource` in namespace `openshift-config`.
+The `ManagedResource` copies the contents of secret `appuio-vsphere-creds` to secret `vsphere-creds` in namespace `kube-system`.
+
+TIP: We deploy a custom secret and a `ManagedResource` so that the vSphere credentials are not directly embedded into the `ManagedResource`'s `spec.template` on the cluster.
+
+NOTE: If parameter `cloud` isn't set to `vsphere`, the contents of this parameter are ignored.
+
 == `motd`
 
 [horizontal]

--- a/tests/golden/vsphere/openshift4-config/openshift4-config/10_aggregate_to_cluster_reader.yaml
+++ b/tests/golden/vsphere/openshift4-config/openshift4-config/10_aggregate_to_cluster_reader.yaml
@@ -1,0 +1,35 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-aggregate-operator-openshift-io-to-cluster-reader
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
+  name: syn:aggregate-operator-openshift-io-to-cluster-reader
+rules:
+  - apiGroups:
+      - operator.openshift.io
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-aggregate-networking-k8s-io-to-cluster-reader
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
+  name: syn:aggregate-networking-k8s-io-to-cluster-reader
+rules:
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch

--- a/tests/golden/vsphere/openshift4-config/openshift4-config/20_vsphere_credentials.yaml
+++ b/tests/golden/vsphere/openshift4-config/openshift4-config/20_vsphere_credentials.yaml
@@ -1,0 +1,114 @@
+apiVersion: espejote.io/v1alpha1
+kind: ManagedResource
+metadata:
+  labels:
+    app.kubernetes.io/name: vsphere-credentials
+  name: vsphere-credentials
+  namespace: openshift-config
+spec:
+  applyOptions:
+    force: true
+  context:
+    - name: source
+      resource:
+        apiVersion: v1
+        kind: Secret
+        name: appuio-vsphere-creds
+        namespace: openshift-config
+  serviceAccountRef:
+    name: vsphere-credentials-manager
+  template: |
+    local esp = import 'espejote.libsonnet';
+
+    local source = esp.context().source;
+    assert
+      std.length(source) == 1
+      : 'Expected source context to have exactly 1 element';
+    assert
+      source[0].kind == 'Secret'
+      : 'Expected source to be a `Secret`, is a `%s`' % source[0].kind;
+
+    {
+      apiVersion: 'v1',
+      kind: 'Secret',
+      metadata: {
+        name: 'vsphere-creds',
+        namespace: 'kube-system',
+        annotations: {
+          'espejote.io/managed-by': 'openshift-config/vsphere-credentials',
+        },
+      },
+      data: source[0].data,
+    }
+  triggers:
+    - name: vsphere-creds
+      watchResource:
+        apiVersion: v1
+        kind: Secret
+        name: vsphere-creds
+        namespace: kube-system
+    - name: source
+      watchContextResource:
+        name: source
+---
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-vsphere-creds
+  name: appuio-vsphere-creds
+  namespace: openshift-config
+stringData:
+  vcenter.example.com.password: t-silent-test-1234/c-green-test-1234/vsphere/credentials/password
+  vcenter.example.com.username: t-silent-test-1234/c-green-test-1234/vsphere/credentials/username
+type: Opaque
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    name: vsphere-credentials-manager
+  name: vsphere-credentials-manager
+  namespace: openshift-config
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: {}
+  labels:
+    name: vsphere-credentials-manager
+  name: vsphere-credentials-manager
+  namespace: kube-system
+rules:
+  - apiGroups:
+      - ''
+    resourceNames:
+      - vsphere-creds
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: vsphere-credentials-manager
+  name: vsphere-credentials-manager
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: vsphere-credentials-manager
+subjects:
+  - kind: ServiceAccount
+    name: vsphere-credentials-manager
+    namespace: openshift-config

--- a/tests/vsphere.yml
+++ b/tests/vsphere.yml
@@ -1,0 +1,13 @@
+parameters:
+  kapitan:
+    dependencies:
+      - type: https
+        source: https://raw.githubusercontent.com/projectsyn/component-espejote/master/lib/espejote.libsonnet
+        output_path: vendor/lib/espejote.libsonnet
+
+  openshift4_config:
+    cloud: vsphere
+    vsphere:
+      vcenterURL: vcenter.example.com
+      username: ?{vaultkv:${cluster:tenant}/${cluster:name}/vsphere/credentials/username}
+      password: ?{vaultkv:${cluster:tenant}/${cluster:name}/vsphere/credentials/password}


### PR DESCRIPTION
Until now, we didn't have a mechanism to deploy the vsphere credentials stored in Vault on the cluster. OpenShift on vSphere automatically propagates the vSphere credentials stored in Secret `vsphere-creds` in namespace `kube-system` to all components that use the credentials (CCM, CSI driver, ...).

The ManagedResource gets rendered if component parameter `cloud` is set to `vsphere`.

The ManagedResource reads the actual vSphere credentials from secret `appuio-vsphere-creds` in namespace `openshift-config` which is rendered from parameter `vsphere`.  The idea is that users set the fields of parameter `vsphere` to suitable values for their cluster(s).

Finally, the commit also adds new test case `vsphere` which renders the new config.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.


<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
