### PR TITLE
Supports managing Networking configuration

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -26,9 +26,9 @@ parameters:
       spec:
         controlPlaneHardwareSpeed: ""
 
-    networking:
+    networkCustomization:
       enabled: true
-      labelConfig: 'networking.openshift-config.syn.tools/include-config'
-      labelOperator: 'networking.openshift-config.syn.tools/include-operator'
+      labelConfig: 'network.openshift-config.syn.tools/include-config'
+      labelOperator: 'network.openshift-config.syn.tools/include-operator'
       specConfig: {}
       specOperator: {}

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -25,3 +25,10 @@ parameters:
       enabled: false
       spec:
         controlPlaneHardwareSpeed: ""
+
+    networking:
+      enabled: true
+      labelConfig: 'networking.openshift-config.syn.tools/include-config'
+      labelOperator: 'networking.openshift-config.syn.tools/include-operator'
+      specConfig: {}
+      specOperator: {}

--- a/component/espejote-templates/manage-networking.jsonnet
+++ b/component/espejote-templates/manage-networking.jsonnet
@@ -1,0 +1,45 @@
+local esp = import 'espejote.libsonnet';
+
+local networking = import 'appuio-networking/networking.libsonnet';
+local spec = import 'appuio-networking/spec.json';
+
+local parseConfigmaps(configmaps) =
+  local nameField = function(obj) obj.metadata.name;
+  std.map(
+    function(obj) std.get(obj.data, 'spec', {}),
+    std.sort(configmaps, nameField)
+  );
+
+local configmapsConfig = parseConfigmaps(esp.context().configmaps_config);
+local configmapsOperator = parseConfigmaps(esp.context().configmaps_operator);
+
+// Builds a new object from its input.
+// All keys which contain an object or array will be suffixed with `+` in the result.
+local makeMergeable(o) = {
+  [key]+: makeMergeable(o[key])
+  for key in std.objectFields(o)
+  if std.isObject(o[key])
+} + {
+  [key]+: o[key]
+  for key in std.objectFields(o)
+  if std.isArray(o[key])
+} + {
+  [key]: o[key]
+  for key in std.objectFields(o)
+  if !std.isObject(o[key]) && !std.isArray(o[key])
+};
+
+local mergeSpec(configmaps, spec) = std.foldl(
+  function(a, b) a + makeMergeable(b),
+  configmaps + [ spec ],
+  {}
+);
+
+[
+  networking.Config {
+    spec: mergeSpec(configmapsConfig, spec.config),
+  },
+  networking.Operator {
+    spec: mergeSpec(configmapsConfig, spec.operator),
+  },
+]

--- a/component/espejote-templates/manage-networking.jsonnet
+++ b/component/espejote-templates/manage-networking.jsonnet
@@ -3,15 +3,15 @@ local esp = import 'espejote.libsonnet';
 local networking = import 'appuio-networking/networking.libsonnet';
 local spec = import 'appuio-networking/spec.json';
 
-local parseConfigmaps(configmaps) =
+local filterConfigmaps(configmaps) =
   local nameField = function(obj) obj.metadata.name;
-  std.map(
-    function(obj) std.get(obj.data, 'spec', {}),
+  std.filter(
+    function(obj) std.objectHas(obj.data, 'spec'),
     std.sort(configmaps, nameField)
   );
 
-local configmapsConfig = parseConfigmaps(esp.context().configmaps_config);
-local configmapsOperator = parseConfigmaps(esp.context().configmaps_operator);
+local configmapsConfig = filterConfigmaps(esp.context().configmaps_config);
+local configmapsOperator = filterConfigmaps(esp.context().configmaps_operator);
 
 // Builds a new object from its input.
 // All keys which contain an object or array will be suffixed with `+` in the result.
@@ -29,17 +29,38 @@ local makeMergeable(o) = {
   if !std.isObject(o[key]) && !std.isArray(o[key])
 };
 
-local mergeSpec(configmaps, spec) = std.foldl(
-  function(a, b) a + makeMergeable(b),
-  configmaps + [ spec ],
-  {}
-);
+local targetMetadata(configmaps) =
+  local cmNames = std.map(
+    function(obj) obj.metadata.name,
+    configmaps
+  );
+  {
+    annotations+: {
+      'network.openshift-config.syn.tools/active-configmaps': std.manifestJsonMinified(cmNames),
+    },
+    labels+: {
+      'app.kubernetes.io/managed-by': 'espejote',
+    },
+  };
+
+local mergeSpec(configmaps, spec) =
+  local cmSpecs = std.map(
+    function(obj) std.parseJson(std.get(obj.data, 'spec', '')),
+    configmaps
+  );
+  std.foldl(
+    function(a, b) a + makeMergeable(b),
+    cmSpecs + [ spec ],
+    {}
+  );
 
 [
   networking.Config {
+    metadata+: targetMetadata(configmapsConfig),
     spec: mergeSpec(configmapsConfig, spec.config),
   },
   networking.Operator {
-    spec: mergeSpec(configmapsConfig, spec.operator),
+    metadata+: targetMetadata(configmapsOperator),
+    spec: mergeSpec(configmapsOperator, spec.operator),
   },
 ]

--- a/component/espejote-templates/networking-helpers.libsonnet
+++ b/component/espejote-templates/networking-helpers.libsonnet
@@ -1,0 +1,35 @@
+local configApiGroup = 'config.openshift.io';
+local configApiVersion = '%s/v1' % configApiGroup;
+local operatorApiGroup = 'operator.openshift.io';
+local operatorApiVersion = '%s/v1' % operatorApiGroup;
+local kind = 'Network';
+local resource = 'networks';
+local resourceName = 'cluster';
+
+local config = {
+  apiVersion: configApiVersion,
+  kind: kind,
+  metadata: {
+    name: resourceName,
+  },
+};
+
+local operator = {
+  apiVersion: operatorApiVersion,
+  kind: kind,
+  metadata: {
+    name: resourceName,
+  },
+};
+
+{
+  configApiGroup: configApiGroup,
+  configApiVersion: configApiVersion,
+  operatorApiGroup: operatorApiGroup,
+  operatorApiVersion: operatorApiVersion,
+  kind: kind,
+  resource: resource,
+  resourceName: resourceName,
+  Config: config,
+  Operator: operator,
+}

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -61,7 +61,7 @@ local vsphere = import 'vsphere.libsonnet';
     import 'pull-secret-sync-job.libsonnet',
   [if std.length(motd) > 0 then '03_motd']: motd,
   [if params.etcdCustomization.enabled then '05_etcd_managedresource']: import 'etcd.libsonnet',
-  [if params.networking.enabled then '05_networking_managedresource']: import 'networking.libsonnet',
+  [if params.networkCustomization.enabled then '05_networking_managedresource']: import 'networking.libsonnet',
   '10_aggregate_to_cluster_reader': import 'aggregated-clusterroles.libsonnet',
   [if params.caBundle != null then '11_ca_bundle']: caBundle,
 } + if params.cloud == 'vsphere' then {

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -61,6 +61,7 @@ local vsphere = import 'vsphere.libsonnet';
     import 'pull-secret-sync-job.libsonnet',
   [if std.length(motd) > 0 then '03_motd']: motd,
   [if params.etcdCustomization.enabled then '05_etcd_managedresource']: import 'etcd.libsonnet',
+  [if params.networking.enabled then '05_networking_managedresource']: import 'networking.libsonnet',
   '10_aggregate_to_cluster_reader': import 'aggregated-clusterroles.libsonnet',
   [if params.caBundle != null then '11_ca_bundle']: caBundle,
 } + if params.cloud == 'vsphere' then {

--- a/component/networking.libsonnet
+++ b/component/networking.libsonnet
@@ -74,8 +74,8 @@ local jl = esp.jsonnetLibrary('appuio-networking', namespace) {
   spec: {
     data: {
       'spec.json': std.manifestJson({
-        config: params.networking.specConfig,
-        operator: params.networking.specOperator,
+        config: params.networkCustomization.specConfig,
+        operator: params.networkCustomization.specOperator,
       }),
       'networking.libsonnet': importstr 'espejote-templates/networking-helpers.libsonnet',
     },
@@ -96,7 +96,7 @@ local mr = esp.managedResource('appuio-networking', namespace) {
           kind: 'ConfigMap',
           labelSelector: {
             matchLabels: {
-              [params.networking.labelConfig]: '',
+              [params.networkCustomization.labelConfig]: '',
             },
           },
         },
@@ -108,7 +108,7 @@ local mr = esp.managedResource('appuio-networking', namespace) {
           kind: 'ConfigMap',
           labelSelector: {
             matchLabels: {
-              [params.networking.labelOperator]: '',
+              [params.networkCustomization.labelOperator]: '',
             },
           },
         },

--- a/component/networking.libsonnet
+++ b/component/networking.libsonnet
@@ -1,0 +1,159 @@
+local kap = import 'lib/kapitan.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+
+local inv = kap.inventory();
+local params = inv.parameters.openshift4_config;
+
+local esp = import 'lib/espejote.libsonnet';
+
+local namespace = 'openshift-config';
+
+local sa = kube.ServiceAccount('appuio-networking-manager') {
+  metadata+: {
+    namespace: namespace,
+  },
+};
+
+local networking = import 'espejote-templates/networking-helpers.libsonnet';
+
+local clusterrole = kube.ClusterRole('appuio:openshift4-config:networking-manager') {
+  rules: [
+    {
+      apiGroups: [ networking.operatorApiGroup ],
+      resources: [ networking.resource ],
+      resourceNames: [ networking.resourceName ],
+      verbs: [ 'get', 'list', 'watch', 'patch' ],
+    },
+    {
+      apiGroups: [ networking.configApiGroup ],
+      resources: [ networking.resource ],
+      resourceNames: [ networking.resourceName ],
+      verbs: [ 'get', 'list', 'watch', 'patch' ],
+    },
+  ],
+};
+
+local clusterrolebinding =
+  kube.ClusterRoleBinding('appuio:openshift4-config:networking-manager') {
+    roleRef_: clusterrole,
+    subjects_: [ sa ],
+  };
+
+local role = kube.Role('appuio:openshift4-config:networking-manager') {
+  metadata+: {
+    namespace: namespace,
+  },
+  rules: [
+    {
+      apiGroups: [ '' ],
+      resources: [ 'configmaps' ],
+      verbs: [ 'get', 'list', 'watch' ],
+    },
+    {
+      apiGroups: [ 'espejote.io' ],
+      resources: [ 'jsonnetlibraries' ],
+      resourceNames: [ 'appuio-networking' ],
+      verbs: [ 'get', 'list', 'watch' ],
+    },
+  ],
+};
+
+local rolebinding =
+  kube.RoleBinding('appuio:openshift4-config:networking-manager') {
+    metadata+: {
+      namespace: namespace,
+    },
+    roleRef_: role,
+    subjects_: [ sa ],
+  };
+
+local jl = esp.jsonnetLibrary('appuio-networking', namespace) {
+  metadata+: {
+    namespace: 'openshift-config',
+  },
+  spec: {
+    data: {
+      'spec.json': std.manifestJson({
+        config: params.networking.specConfig,
+        operator: params.networking.specOperator,
+      }),
+      'networking.libsonnet': importstr 'espejote-templates/networking-helpers.libsonnet',
+    },
+  },
+};
+
+local mr = esp.managedResource('appuio-networking', namespace) {
+  spec: {
+    // Set force=true so we can take ownership of previously manually edited
+    // fields in `spec`.
+    applyOptions: { force: true },
+    serviceAccountRef: { name: sa.metadata.name },
+    context: [
+      {
+        name: 'configmaps_config',
+        resource: {
+          apiVersion: 'v1',
+          kind: 'ConfigMap',
+          labelSelector: {
+            matchLabels: {
+              [params.networking.labelConfig]: '',
+            },
+          },
+        },
+      },
+      {
+        name: 'configmaps_operator',
+        resource: {
+          apiVersion: 'v1',
+          kind: 'ConfigMap',
+          labelSelector: {
+            matchLabels: {
+              [params.networking.labelOperator]: '',
+            },
+          },
+        },
+      },
+    ],
+    triggers: [
+      {
+        name: 'jsonnetlib',
+        watchResource: {
+          apiVersion: jl.apiVersion,
+          kind: jl.kind,
+          name: jl.metadata.name,
+        },
+      },
+      {
+        name: 'networking_config',
+        watchResource: {
+          apiVersion: networking.configApiVersion,
+          kind: networking.kind,
+          name: networking.resourceName,
+        },
+      },
+      {
+        name: 'networking_operator',
+        watchResource: {
+          apiVersion: networking.operatorApiVersion,
+          kind: networking.kind,
+          name: networking.resourceName,
+        },
+      },
+      {
+        name: 'configmap_config',
+        watchContextResource: {
+          name: 'configmaps_config',
+        },
+      },
+      {
+        name: 'configmap_operator',
+        watchContextResource: {
+          name: 'configmaps_operator',
+        },
+      },
+    ],
+    template: importstr 'espejote-templates/manage-networking.jsonnet',
+  },
+};
+
+[ sa, clusterrole, clusterrolebinding, role, rolebinding, jl, mr ]

--- a/docs/modules/ROOT/pages/how-tos/networking-config.adoc
+++ b/docs/modules/ROOT/pages/how-tos/networking-config.adoc
@@ -5,8 +5,12 @@ This component is managing the following OpenShift resources:
 * `networks.config.openshift.io/cluster`
 * `networks.operator.openshift.io/cluster`
 
-Other components can create `ConfigMaps` with their own spec for above resources,
-the `ManagedResource` will merge the specs of these `ConfigMaps` into the final configuration.
+Other components can create `ConfigMaps` with their own spec for these resources.
+The `ManagedResource` will merge the specs of these `ConfigMaps` into the final configuration.
+
+If multiple configmaps are setting the same field, configmap precedence is determined by ascibetically sorting the configmaps by their `metadata.name`.
+Configmaps which sort later have higher precedence.
+Values set through the component parameters have higher precedence than any values set through configmaps.
 
 
 == Example
@@ -28,12 +32,12 @@ data: <4>
         "deployKubeProxy": false
     }
 ----
-<1> Apply a label to the `ConfigMap`, see xref:references/parameters.adoc#_networking_labelconfig_and_networking_labeloperator[Parameters] for the values.
+<1> Label the `ConfigMap` so it's picked up by the `ManagedResource`, see xref:references/parameters.adoc#_networkcustomization_labelconfig_and_networkcustomization_labeloperator[Parameters] for the values.
 <2> The `ConfigMaps` will get sorted by their name before merging.
-<3> Applt the `ConfigMap` to the `openshift-config` namespace.
+<3> Apply the `ConfigMap` to the `openshift-config` namespace.
 <4> Use the key `spec` for your configuration
 
 [IMPORTANT]
 ====
-The configuration from xref:references/parameters.adoc#_networking_specconfig_and_networking_specoperator[this component] will take precendence over any `ConfigMaps`.
+The configuration from xref:references/parameters.adoc#_networkcustomization_specconfig_and_networkcustomization_specoperator[this component] will take precendence over any `ConfigMaps`.
 ====

--- a/docs/modules/ROOT/pages/how-tos/networking-config.adoc
+++ b/docs/modules/ROOT/pages/how-tos/networking-config.adoc
@@ -1,0 +1,39 @@
+# Use ConfigMap to merge Networking Config
+
+This component is managing the following OpenShift resources:
+
+* `networks.config.openshift.io/cluster`
+* `networks.operator.openshift.io/cluster`
+
+Other components can create `ConfigMaps` with their own spec for above resources,
+the `ManagedResource` will merge the specs of these `ConfigMaps` into the final configuration.
+
+
+== Example
+
+Create a `ConfigMap` in your component:
+
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    networking.openshift-config.syn.tools/include-operator: "" <1>
+  name: cilium-kubeproxy <2>
+  namespace: openshift-config <3>
+data: <4>
+  spec: |-
+    {
+        "deployKubeProxy": false
+    }
+----
+<1> Apply a label to the `ConfigMap`, see xref:references/parameters.adoc#_networking_labelconfig_and_networking_labeloperator[Parameters] for the values.
+<2> The `ConfigMaps` will get sorted by their name before merging.
+<3> Applt the `ConfigMap` to the `openshift-config` namespace.
+<4> Use the key `spec` for your configuration
+
+[IMPORTANT]
+====
+The configuration from xref:references/parameters.adoc#_networking_specconfig_and_networking_specoperator[this component] will take precendence over any `ConfigMaps`.
+====

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -168,7 +168,7 @@ A partial `spec` for the OpenShift 4 `Etcd` custom resource.
 See the https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/operator_apis/etcd-operator-openshift-io-v1#spec-11[upstream API documentation] for available fields.
 
 
-== `networking`
+== `networkCustomization`
 
 [horizontal]
 type:: dictionary
@@ -176,16 +176,16 @@ type:: dictionary
 This parameter allows customizing the cluster's networking.
 The implementation uses https://github.com/vshn/espejote[Espejote] to reconcile our customizations for the `networks.config.openshift.io/cluster` and `networks.operator.openshift.io/cluster` resource.
 
-=== `networking.enabled`
+=== `networkCustomization.enabled`
 
 [horizontal]
 type:: boolean
 default:: `true`
 
 Whether to deploy the Espejote managed resource on the cluster.
-If this parameter is set to `false`, changing the contents of `networking` has no effect.
+If this parameter is set to `false`, changing the contents of `networkCustomization` has no effect.
 
-=== `networking.labelConfig` and `networking.labelOperator`
+=== `networkCustomization.labelConfig` and `networkCustomization.labelOperator`
 
 [horizontal]
 type:: string
@@ -208,7 +208,7 @@ The ManagedResource collects all configmaps and sorts them by name before mergin
 The config specified in this component will have precedence over any conflicting config in the configmaps.
 ====
 
-=== `networking.specConfig` and `networking.specOperator`
+=== `networkCustomization.specConfig` and `networkCustomization.specOperator`
 
 [horizontal]
 type:: string

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -166,3 +166,58 @@ default:: https://github.com/appuio/component-openshift4-config/blob/master/clas
 
 A partial `spec` for the OpenShift 4 `Etcd` custom resource.
 See the https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/operator_apis/etcd-operator-openshift-io-v1#spec-11[upstream API documentation] for available fields.
+
+
+== `networking`
+
+[horizontal]
+type:: dictionary
+
+This parameter allows customizing the cluster's networking.
+The implementation uses https://github.com/vshn/espejote[Espejote] to reconcile our customizations for the `networks.config.openshift.io/cluster` and `networks.operator.openshift.io/cluster` resource.
+
+=== `networking.enabled`
+
+[horizontal]
+type:: boolean
+default:: `true`
+
+Whether to deploy the Espejote managed resource on the cluster.
+If this parameter is set to `false`, changing the contents of `networking` has no effect.
+
+=== `networking.labelConfig` and `networking.labelOperator`
+
+[horizontal]
+type:: string
+default::
++
+[source,text]
+----
+labelConfig: 'network.openshift-config.syn.tools/include-config'
+labelOperator: 'network.openshift-config.syn.tools/include-operator'
+----
+
+Other components can create configmaps in the `openshift-config` namespace with their own spec for the cluster resources.
+If they label those configmaps with these keys, they get merged into the final configuration.
+
+For more information, see xref:how-tos/networking-config.adoc[].
+
+[IMPORTANT]
+====
+The ManagedResource collects all configmaps and sorts them by name before merging the specs into the configuration.
+The config specified in this component will have precedence over any conflicting config in the configmaps.
+====
+
+=== `networking.specConfig` and `networking.specOperator`
+
+[horizontal]
+type:: string
+default::
++
+[source,text]
+----
+specConfig: {}
+specOperator: {}
+----
+
+This are the specs for the resources `networks.config.openshift.io/cluster` and `networks.operator.openshift.io/cluster`.

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -2,6 +2,7 @@
 
 .How-to guides
 * xref:how-tos/migrate-v1.adoc[]
+* xref:how-tos/networking-config.adoc[]
 
 .Technical reference
 * xref:references/parameters.adoc[Parameters]

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -1,2 +1,8 @@
 parameters:
+  kapitan:
+    dependencies:
+      - type: https
+        source: https://raw.githubusercontent.com/projectsyn/component-espejote/master/lib/espejote.libsonnet
+        output_path: vendor/lib/espejote.libsonnet
+
   openshift4_config: {}

--- a/tests/etcd.yml
+++ b/tests/etcd.yml
@@ -2,7 +2,7 @@ parameters:
   kapitan:
     dependencies:
       - type: https
-        source: https://raw.githubusercontent.com/projectsyn/component-espejote/v0.5.0/lib/espejote.libsonnet
+        source: https://raw.githubusercontent.com/projectsyn/component-espejote/master/lib/espejote.libsonnet
         output_path: vendor/lib/espejote.libsonnet
 
   openshift4_config:

--- a/tests/golden/defaults/openshift4-config/openshift4-config/05_networking_managedresource.yaml
+++ b/tests/golden/defaults/openshift4-config/openshift4-config/05_networking_managedresource.yaml
@@ -175,14 +175,14 @@ spec:
         kind: ConfigMap
         labelSelector:
           matchLabels:
-            networking.openshift-config.syn.tools/include-config: ''
+            network.openshift-config.syn.tools/include-config: ''
     - name: configmaps_operator
       resource:
         apiVersion: v1
         kind: ConfigMap
         labelSelector:
           matchLabels:
-            networking.openshift-config.syn.tools/include-operator: ''
+            network.openshift-config.syn.tools/include-operator: ''
   serviceAccountRef:
     name: appuio-networking-manager
   template: |
@@ -191,15 +191,15 @@ spec:
     local networking = import 'appuio-networking/networking.libsonnet';
     local spec = import 'appuio-networking/spec.json';
 
-    local parseConfigmaps(configmaps) =
+    local filterConfigmaps(configmaps) =
       local nameField = function(obj) obj.metadata.name;
-      std.map(
-        function(obj) std.get(obj.data, 'spec', {}),
+      std.filter(
+        function(obj) std.objectHas(obj.data, 'spec'),
         std.sort(configmaps, nameField)
       );
 
-    local configmapsConfig = parseConfigmaps(esp.context().configmaps_config);
-    local configmapsOperator = parseConfigmaps(esp.context().configmaps_operator);
+    local configmapsConfig = filterConfigmaps(esp.context().configmaps_config);
+    local configmapsOperator = filterConfigmaps(esp.context().configmaps_operator);
 
     // Builds a new object from its input.
     // All keys which contain an object or array will be suffixed with `+` in the result.
@@ -217,18 +217,39 @@ spec:
       if !std.isObject(o[key]) && !std.isArray(o[key])
     };
 
-    local mergeSpec(configmaps, spec) = std.foldl(
-      function(a, b) a + makeMergeable(b),
-      configmaps + [ spec ],
-      {}
-    );
+    local targetMetadata(configmaps) =
+      local cmNames = std.map(
+        function(obj) obj.metadata.name,
+        configmaps
+      );
+      {
+        annotations+: {
+          'network.openshift-config.syn.tools/active-configmaps': std.manifestJsonMinified(cmNames),
+        },
+        labels+: {
+          'app.kubernetes.io/managed-by': 'espejote',
+        },
+      };
+
+    local mergeSpec(configmaps, spec) =
+      local cmSpecs = std.map(
+        function(obj) std.parseJson(std.get(obj.data, 'spec', '')),
+        configmaps
+      );
+      std.foldl(
+        function(a, b) a + makeMergeable(b),
+        cmSpecs + [ spec ],
+        {}
+      );
 
     [
       networking.Config {
+        metadata+: targetMetadata(configmapsConfig),
         spec: mergeSpec(configmapsConfig, spec.config),
       },
       networking.Operator {
-        spec: mergeSpec(configmapsConfig, spec.operator),
+        metadata+: targetMetadata(configmapsOperator),
+        spec: mergeSpec(configmapsOperator, spec.operator),
       },
     ]
   triggers:

--- a/tests/golden/defaults/openshift4-config/openshift4-config/05_networking_managedresource.yaml
+++ b/tests/golden/defaults/openshift4-config/openshift4-config/05_networking_managedresource.yaml
@@ -1,0 +1,255 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-networking-manager
+  name: appuio-networking-manager
+  namespace: openshift-config
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-openshift4-config-networking-manager
+  name: appuio:openshift4-config:networking-manager
+rules:
+  - apiGroups:
+      - operator.openshift.io
+    resourceNames:
+      - cluster
+    resources:
+      - networks
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+  - apiGroups:
+      - config.openshift.io
+    resourceNames:
+      - cluster
+    resources:
+      - networks
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-openshift4-config-networking-manager
+  name: appuio:openshift4-config:networking-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appuio:openshift4-config:networking-manager
+subjects:
+  - kind: ServiceAccount
+    name: appuio-networking-manager
+    namespace: openshift-config
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-openshift4-config-networking-manager
+  name: appuio:openshift4-config:networking-manager
+  namespace: openshift-config
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - espejote.io
+    resourceNames:
+      - appuio-networking
+    resources:
+      - jsonnetlibraries
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-openshift4-config-networking-manager
+  name: appuio:openshift4-config:networking-manager
+  namespace: openshift-config
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: appuio:openshift4-config:networking-manager
+subjects:
+  - kind: ServiceAccount
+    name: appuio-networking-manager
+    namespace: openshift-config
+---
+apiVersion: espejote.io/v1alpha1
+kind: JsonnetLibrary
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  labels:
+    app.kubernetes.io/name: appuio-networking
+  name: appuio-networking
+  namespace: openshift-config
+spec:
+  data:
+    networking.libsonnet: |
+      local configApiGroup = 'config.openshift.io';
+      local configApiVersion = '%s/v1' % configApiGroup;
+      local operatorApiGroup = 'operator.openshift.io';
+      local operatorApiVersion = '%s/v1' % operatorApiGroup;
+      local kind = 'Network';
+      local resource = 'networks';
+      local resourceName = 'cluster';
+
+      local config = {
+        apiVersion: configApiVersion,
+        kind: kind,
+        metadata: {
+          name: resourceName,
+        },
+      };
+
+      local operator = {
+        apiVersion: operatorApiVersion,
+        kind: kind,
+        metadata: {
+          name: resourceName,
+        },
+      };
+
+      {
+        configApiGroup: configApiGroup,
+        configApiVersion: configApiVersion,
+        operatorApiGroup: operatorApiGroup,
+        operatorApiVersion: operatorApiVersion,
+        kind: kind,
+        resource: resource,
+        resourceName: resourceName,
+        Config: config,
+        Operator: operator,
+      }
+    spec.json: |-
+      {
+          "config": {
+
+          },
+          "operator": {
+
+          }
+      }
+---
+apiVersion: espejote.io/v1alpha1
+kind: ManagedResource
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  labels:
+    app.kubernetes.io/name: appuio-networking
+  name: appuio-networking
+  namespace: openshift-config
+spec:
+  applyOptions:
+    force: true
+  context:
+    - name: configmaps_config
+      resource:
+        apiVersion: v1
+        kind: ConfigMap
+        labelSelector:
+          matchLabels:
+            networking.openshift-config.syn.tools/include-config: ''
+    - name: configmaps_operator
+      resource:
+        apiVersion: v1
+        kind: ConfigMap
+        labelSelector:
+          matchLabels:
+            networking.openshift-config.syn.tools/include-operator: ''
+  serviceAccountRef:
+    name: appuio-networking-manager
+  template: |
+    local esp = import 'espejote.libsonnet';
+
+    local networking = import 'appuio-networking/networking.libsonnet';
+    local spec = import 'appuio-networking/spec.json';
+
+    local parseConfigmaps(configmaps) =
+      local nameField = function(obj) obj.metadata.name;
+      std.map(
+        function(obj) std.get(obj.data, 'spec', {}),
+        std.sort(configmaps, nameField)
+      );
+
+    local configmapsConfig = parseConfigmaps(esp.context().configmaps_config);
+    local configmapsOperator = parseConfigmaps(esp.context().configmaps_operator);
+
+    // Builds a new object from its input.
+    // All keys which contain an object or array will be suffixed with `+` in the result.
+    local makeMergeable(o) = {
+      [key]+: makeMergeable(o[key])
+      for key in std.objectFields(o)
+      if std.isObject(o[key])
+    } + {
+      [key]+: o[key]
+      for key in std.objectFields(o)
+      if std.isArray(o[key])
+    } + {
+      [key]: o[key]
+      for key in std.objectFields(o)
+      if !std.isObject(o[key]) && !std.isArray(o[key])
+    };
+
+    local mergeSpec(configmaps, spec) = std.foldl(
+      function(a, b) a + makeMergeable(b),
+      configmaps + [ spec ],
+      {}
+    );
+
+    [
+      networking.Config {
+        spec: mergeSpec(configmapsConfig, spec.config),
+      },
+      networking.Operator {
+        spec: mergeSpec(configmapsConfig, spec.operator),
+      },
+    ]
+  triggers:
+    - name: jsonnetlib
+      watchResource:
+        apiVersion: espejote.io/v1alpha1
+        kind: JsonnetLibrary
+        name: appuio-networking
+    - name: networking_config
+      watchResource:
+        apiVersion: config.openshift.io/v1
+        kind: Network
+        name: cluster
+    - name: networking_operator
+      watchResource:
+        apiVersion: operator.openshift.io/v1
+        kind: Network
+        name: cluster
+    - name: configmap_config
+      watchContextResource:
+        name: configmaps_config
+    - name: configmap_operator
+      watchContextResource:
+        name: configmaps_operator

--- a/tests/golden/etcd/openshift4-config/openshift4-config/05_etcd_managedresource.yaml
+++ b/tests/golden/etcd/openshift4-config/openshift4-config/05_etcd_managedresource.yaml
@@ -46,6 +46,8 @@ subjects:
 apiVersion: espejote.io/v1alpha1
 kind: JsonnetLibrary
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     app.kubernetes.io/name: appuio-etcd
   name: appuio-etcd
@@ -83,6 +85,8 @@ spec:
 apiVersion: espejote.io/v1alpha1
 kind: ManagedResource
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     app.kubernetes.io/name: appuio-etcd
   name: appuio-etcd

--- a/tests/golden/etcd/openshift4-config/openshift4-config/05_networking_managedresource.yaml
+++ b/tests/golden/etcd/openshift4-config/openshift4-config/05_networking_managedresource.yaml
@@ -175,14 +175,14 @@ spec:
         kind: ConfigMap
         labelSelector:
           matchLabels:
-            networking.openshift-config.syn.tools/include-config: ''
+            network.openshift-config.syn.tools/include-config: ''
     - name: configmaps_operator
       resource:
         apiVersion: v1
         kind: ConfigMap
         labelSelector:
           matchLabels:
-            networking.openshift-config.syn.tools/include-operator: ''
+            network.openshift-config.syn.tools/include-operator: ''
   serviceAccountRef:
     name: appuio-networking-manager
   template: |
@@ -191,15 +191,15 @@ spec:
     local networking = import 'appuio-networking/networking.libsonnet';
     local spec = import 'appuio-networking/spec.json';
 
-    local parseConfigmaps(configmaps) =
+    local filterConfigmaps(configmaps) =
       local nameField = function(obj) obj.metadata.name;
-      std.map(
-        function(obj) std.get(obj.data, 'spec', {}),
+      std.filter(
+        function(obj) std.objectHas(obj.data, 'spec'),
         std.sort(configmaps, nameField)
       );
 
-    local configmapsConfig = parseConfigmaps(esp.context().configmaps_config);
-    local configmapsOperator = parseConfigmaps(esp.context().configmaps_operator);
+    local configmapsConfig = filterConfigmaps(esp.context().configmaps_config);
+    local configmapsOperator = filterConfigmaps(esp.context().configmaps_operator);
 
     // Builds a new object from its input.
     // All keys which contain an object or array will be suffixed with `+` in the result.
@@ -217,18 +217,39 @@ spec:
       if !std.isObject(o[key]) && !std.isArray(o[key])
     };
 
-    local mergeSpec(configmaps, spec) = std.foldl(
-      function(a, b) a + makeMergeable(b),
-      configmaps + [ spec ],
-      {}
-    );
+    local targetMetadata(configmaps) =
+      local cmNames = std.map(
+        function(obj) obj.metadata.name,
+        configmaps
+      );
+      {
+        annotations+: {
+          'network.openshift-config.syn.tools/active-configmaps': std.manifestJsonMinified(cmNames),
+        },
+        labels+: {
+          'app.kubernetes.io/managed-by': 'espejote',
+        },
+      };
+
+    local mergeSpec(configmaps, spec) =
+      local cmSpecs = std.map(
+        function(obj) std.parseJson(std.get(obj.data, 'spec', '')),
+        configmaps
+      );
+      std.foldl(
+        function(a, b) a + makeMergeable(b),
+        cmSpecs + [ spec ],
+        {}
+      );
 
     [
       networking.Config {
+        metadata+: targetMetadata(configmapsConfig),
         spec: mergeSpec(configmapsConfig, spec.config),
       },
       networking.Operator {
-        spec: mergeSpec(configmapsConfig, spec.operator),
+        metadata+: targetMetadata(configmapsOperator),
+        spec: mergeSpec(configmapsOperator, spec.operator),
       },
     ]
   triggers:

--- a/tests/golden/etcd/openshift4-config/openshift4-config/05_networking_managedresource.yaml
+++ b/tests/golden/etcd/openshift4-config/openshift4-config/05_networking_managedresource.yaml
@@ -1,0 +1,255 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-networking-manager
+  name: appuio-networking-manager
+  namespace: openshift-config
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-openshift4-config-networking-manager
+  name: appuio:openshift4-config:networking-manager
+rules:
+  - apiGroups:
+      - operator.openshift.io
+    resourceNames:
+      - cluster
+    resources:
+      - networks
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+  - apiGroups:
+      - config.openshift.io
+    resourceNames:
+      - cluster
+    resources:
+      - networks
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-openshift4-config-networking-manager
+  name: appuio:openshift4-config:networking-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appuio:openshift4-config:networking-manager
+subjects:
+  - kind: ServiceAccount
+    name: appuio-networking-manager
+    namespace: openshift-config
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-openshift4-config-networking-manager
+  name: appuio:openshift4-config:networking-manager
+  namespace: openshift-config
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - espejote.io
+    resourceNames:
+      - appuio-networking
+    resources:
+      - jsonnetlibraries
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-openshift4-config-networking-manager
+  name: appuio:openshift4-config:networking-manager
+  namespace: openshift-config
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: appuio:openshift4-config:networking-manager
+subjects:
+  - kind: ServiceAccount
+    name: appuio-networking-manager
+    namespace: openshift-config
+---
+apiVersion: espejote.io/v1alpha1
+kind: JsonnetLibrary
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  labels:
+    app.kubernetes.io/name: appuio-networking
+  name: appuio-networking
+  namespace: openshift-config
+spec:
+  data:
+    networking.libsonnet: |
+      local configApiGroup = 'config.openshift.io';
+      local configApiVersion = '%s/v1' % configApiGroup;
+      local operatorApiGroup = 'operator.openshift.io';
+      local operatorApiVersion = '%s/v1' % operatorApiGroup;
+      local kind = 'Network';
+      local resource = 'networks';
+      local resourceName = 'cluster';
+
+      local config = {
+        apiVersion: configApiVersion,
+        kind: kind,
+        metadata: {
+          name: resourceName,
+        },
+      };
+
+      local operator = {
+        apiVersion: operatorApiVersion,
+        kind: kind,
+        metadata: {
+          name: resourceName,
+        },
+      };
+
+      {
+        configApiGroup: configApiGroup,
+        configApiVersion: configApiVersion,
+        operatorApiGroup: operatorApiGroup,
+        operatorApiVersion: operatorApiVersion,
+        kind: kind,
+        resource: resource,
+        resourceName: resourceName,
+        Config: config,
+        Operator: operator,
+      }
+    spec.json: |-
+      {
+          "config": {
+
+          },
+          "operator": {
+
+          }
+      }
+---
+apiVersion: espejote.io/v1alpha1
+kind: ManagedResource
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  labels:
+    app.kubernetes.io/name: appuio-networking
+  name: appuio-networking
+  namespace: openshift-config
+spec:
+  applyOptions:
+    force: true
+  context:
+    - name: configmaps_config
+      resource:
+        apiVersion: v1
+        kind: ConfigMap
+        labelSelector:
+          matchLabels:
+            networking.openshift-config.syn.tools/include-config: ''
+    - name: configmaps_operator
+      resource:
+        apiVersion: v1
+        kind: ConfigMap
+        labelSelector:
+          matchLabels:
+            networking.openshift-config.syn.tools/include-operator: ''
+  serviceAccountRef:
+    name: appuio-networking-manager
+  template: |
+    local esp = import 'espejote.libsonnet';
+
+    local networking = import 'appuio-networking/networking.libsonnet';
+    local spec = import 'appuio-networking/spec.json';
+
+    local parseConfigmaps(configmaps) =
+      local nameField = function(obj) obj.metadata.name;
+      std.map(
+        function(obj) std.get(obj.data, 'spec', {}),
+        std.sort(configmaps, nameField)
+      );
+
+    local configmapsConfig = parseConfigmaps(esp.context().configmaps_config);
+    local configmapsOperator = parseConfigmaps(esp.context().configmaps_operator);
+
+    // Builds a new object from its input.
+    // All keys which contain an object or array will be suffixed with `+` in the result.
+    local makeMergeable(o) = {
+      [key]+: makeMergeable(o[key])
+      for key in std.objectFields(o)
+      if std.isObject(o[key])
+    } + {
+      [key]+: o[key]
+      for key in std.objectFields(o)
+      if std.isArray(o[key])
+    } + {
+      [key]: o[key]
+      for key in std.objectFields(o)
+      if !std.isObject(o[key]) && !std.isArray(o[key])
+    };
+
+    local mergeSpec(configmaps, spec) = std.foldl(
+      function(a, b) a + makeMergeable(b),
+      configmaps + [ spec ],
+      {}
+    );
+
+    [
+      networking.Config {
+        spec: mergeSpec(configmapsConfig, spec.config),
+      },
+      networking.Operator {
+        spec: mergeSpec(configmapsConfig, spec.operator),
+      },
+    ]
+  triggers:
+    - name: jsonnetlib
+      watchResource:
+        apiVersion: espejote.io/v1alpha1
+        kind: JsonnetLibrary
+        name: appuio-networking
+    - name: networking_config
+      watchResource:
+        apiVersion: config.openshift.io/v1
+        kind: Network
+        name: cluster
+    - name: networking_operator
+      watchResource:
+        apiVersion: operator.openshift.io/v1
+        kind: Network
+        name: cluster
+    - name: configmap_config
+      watchContextResource:
+        name: configmaps_config
+    - name: configmap_operator
+      watchContextResource:
+        name: configmaps_operator

--- a/tests/golden/motd/openshift4-config/openshift4-config/03_motd.yaml
+++ b/tests/golden/motd/openshift4-config/openshift4-config/03_motd.yaml
@@ -73,6 +73,8 @@ spec:
 apiVersion: espejote.io/v1alpha1
 kind: JsonnetLibrary
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     app.kubernetes.io/name: motd
   name: motd

--- a/tests/golden/motd/openshift4-config/openshift4-config/05_networking_managedresource.yaml
+++ b/tests/golden/motd/openshift4-config/openshift4-config/05_networking_managedresource.yaml
@@ -175,14 +175,14 @@ spec:
         kind: ConfigMap
         labelSelector:
           matchLabels:
-            networking.openshift-config.syn.tools/include-config: ''
+            network.openshift-config.syn.tools/include-config: ''
     - name: configmaps_operator
       resource:
         apiVersion: v1
         kind: ConfigMap
         labelSelector:
           matchLabels:
-            networking.openshift-config.syn.tools/include-operator: ''
+            network.openshift-config.syn.tools/include-operator: ''
   serviceAccountRef:
     name: appuio-networking-manager
   template: |
@@ -191,15 +191,15 @@ spec:
     local networking = import 'appuio-networking/networking.libsonnet';
     local spec = import 'appuio-networking/spec.json';
 
-    local parseConfigmaps(configmaps) =
+    local filterConfigmaps(configmaps) =
       local nameField = function(obj) obj.metadata.name;
-      std.map(
-        function(obj) std.get(obj.data, 'spec', {}),
+      std.filter(
+        function(obj) std.objectHas(obj.data, 'spec'),
         std.sort(configmaps, nameField)
       );
 
-    local configmapsConfig = parseConfigmaps(esp.context().configmaps_config);
-    local configmapsOperator = parseConfigmaps(esp.context().configmaps_operator);
+    local configmapsConfig = filterConfigmaps(esp.context().configmaps_config);
+    local configmapsOperator = filterConfigmaps(esp.context().configmaps_operator);
 
     // Builds a new object from its input.
     // All keys which contain an object or array will be suffixed with `+` in the result.
@@ -217,18 +217,39 @@ spec:
       if !std.isObject(o[key]) && !std.isArray(o[key])
     };
 
-    local mergeSpec(configmaps, spec) = std.foldl(
-      function(a, b) a + makeMergeable(b),
-      configmaps + [ spec ],
-      {}
-    );
+    local targetMetadata(configmaps) =
+      local cmNames = std.map(
+        function(obj) obj.metadata.name,
+        configmaps
+      );
+      {
+        annotations+: {
+          'network.openshift-config.syn.tools/active-configmaps': std.manifestJsonMinified(cmNames),
+        },
+        labels+: {
+          'app.kubernetes.io/managed-by': 'espejote',
+        },
+      };
+
+    local mergeSpec(configmaps, spec) =
+      local cmSpecs = std.map(
+        function(obj) std.parseJson(std.get(obj.data, 'spec', '')),
+        configmaps
+      );
+      std.foldl(
+        function(a, b) a + makeMergeable(b),
+        cmSpecs + [ spec ],
+        {}
+      );
 
     [
       networking.Config {
+        metadata+: targetMetadata(configmapsConfig),
         spec: mergeSpec(configmapsConfig, spec.config),
       },
       networking.Operator {
-        spec: mergeSpec(configmapsConfig, spec.operator),
+        metadata+: targetMetadata(configmapsOperator),
+        spec: mergeSpec(configmapsOperator, spec.operator),
       },
     ]
   triggers:

--- a/tests/golden/motd/openshift4-config/openshift4-config/05_networking_managedresource.yaml
+++ b/tests/golden/motd/openshift4-config/openshift4-config/05_networking_managedresource.yaml
@@ -1,0 +1,255 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-networking-manager
+  name: appuio-networking-manager
+  namespace: openshift-config
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-openshift4-config-networking-manager
+  name: appuio:openshift4-config:networking-manager
+rules:
+  - apiGroups:
+      - operator.openshift.io
+    resourceNames:
+      - cluster
+    resources:
+      - networks
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+  - apiGroups:
+      - config.openshift.io
+    resourceNames:
+      - cluster
+    resources:
+      - networks
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-openshift4-config-networking-manager
+  name: appuio:openshift4-config:networking-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appuio:openshift4-config:networking-manager
+subjects:
+  - kind: ServiceAccount
+    name: appuio-networking-manager
+    namespace: openshift-config
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-openshift4-config-networking-manager
+  name: appuio:openshift4-config:networking-manager
+  namespace: openshift-config
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - espejote.io
+    resourceNames:
+      - appuio-networking
+    resources:
+      - jsonnetlibraries
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-openshift4-config-networking-manager
+  name: appuio:openshift4-config:networking-manager
+  namespace: openshift-config
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: appuio:openshift4-config:networking-manager
+subjects:
+  - kind: ServiceAccount
+    name: appuio-networking-manager
+    namespace: openshift-config
+---
+apiVersion: espejote.io/v1alpha1
+kind: JsonnetLibrary
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  labels:
+    app.kubernetes.io/name: appuio-networking
+  name: appuio-networking
+  namespace: openshift-config
+spec:
+  data:
+    networking.libsonnet: |
+      local configApiGroup = 'config.openshift.io';
+      local configApiVersion = '%s/v1' % configApiGroup;
+      local operatorApiGroup = 'operator.openshift.io';
+      local operatorApiVersion = '%s/v1' % operatorApiGroup;
+      local kind = 'Network';
+      local resource = 'networks';
+      local resourceName = 'cluster';
+
+      local config = {
+        apiVersion: configApiVersion,
+        kind: kind,
+        metadata: {
+          name: resourceName,
+        },
+      };
+
+      local operator = {
+        apiVersion: operatorApiVersion,
+        kind: kind,
+        metadata: {
+          name: resourceName,
+        },
+      };
+
+      {
+        configApiGroup: configApiGroup,
+        configApiVersion: configApiVersion,
+        operatorApiGroup: operatorApiGroup,
+        operatorApiVersion: operatorApiVersion,
+        kind: kind,
+        resource: resource,
+        resourceName: resourceName,
+        Config: config,
+        Operator: operator,
+      }
+    spec.json: |-
+      {
+          "config": {
+
+          },
+          "operator": {
+
+          }
+      }
+---
+apiVersion: espejote.io/v1alpha1
+kind: ManagedResource
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  labels:
+    app.kubernetes.io/name: appuio-networking
+  name: appuio-networking
+  namespace: openshift-config
+spec:
+  applyOptions:
+    force: true
+  context:
+    - name: configmaps_config
+      resource:
+        apiVersion: v1
+        kind: ConfigMap
+        labelSelector:
+          matchLabels:
+            networking.openshift-config.syn.tools/include-config: ''
+    - name: configmaps_operator
+      resource:
+        apiVersion: v1
+        kind: ConfigMap
+        labelSelector:
+          matchLabels:
+            networking.openshift-config.syn.tools/include-operator: ''
+  serviceAccountRef:
+    name: appuio-networking-manager
+  template: |
+    local esp = import 'espejote.libsonnet';
+
+    local networking = import 'appuio-networking/networking.libsonnet';
+    local spec = import 'appuio-networking/spec.json';
+
+    local parseConfigmaps(configmaps) =
+      local nameField = function(obj) obj.metadata.name;
+      std.map(
+        function(obj) std.get(obj.data, 'spec', {}),
+        std.sort(configmaps, nameField)
+      );
+
+    local configmapsConfig = parseConfigmaps(esp.context().configmaps_config);
+    local configmapsOperator = parseConfigmaps(esp.context().configmaps_operator);
+
+    // Builds a new object from its input.
+    // All keys which contain an object or array will be suffixed with `+` in the result.
+    local makeMergeable(o) = {
+      [key]+: makeMergeable(o[key])
+      for key in std.objectFields(o)
+      if std.isObject(o[key])
+    } + {
+      [key]+: o[key]
+      for key in std.objectFields(o)
+      if std.isArray(o[key])
+    } + {
+      [key]: o[key]
+      for key in std.objectFields(o)
+      if !std.isObject(o[key]) && !std.isArray(o[key])
+    };
+
+    local mergeSpec(configmaps, spec) = std.foldl(
+      function(a, b) a + makeMergeable(b),
+      configmaps + [ spec ],
+      {}
+    );
+
+    [
+      networking.Config {
+        spec: mergeSpec(configmapsConfig, spec.config),
+      },
+      networking.Operator {
+        spec: mergeSpec(configmapsConfig, spec.operator),
+      },
+    ]
+  triggers:
+    - name: jsonnetlib
+      watchResource:
+        apiVersion: espejote.io/v1alpha1
+        kind: JsonnetLibrary
+        name: appuio-networking
+    - name: networking_config
+      watchResource:
+        apiVersion: config.openshift.io/v1
+        kind: Network
+        name: cluster
+    - name: networking_operator
+      watchResource:
+        apiVersion: operator.openshift.io/v1
+        kind: Network
+        name: cluster
+    - name: configmap_config
+      watchContextResource:
+        name: configmaps_config
+    - name: configmap_operator
+      watchContextResource:
+        name: configmaps_operator

--- a/tests/golden/pull-secret/openshift4-config/openshift4-config/05_networking_managedresource.yaml
+++ b/tests/golden/pull-secret/openshift4-config/openshift4-config/05_networking_managedresource.yaml
@@ -175,14 +175,14 @@ spec:
         kind: ConfigMap
         labelSelector:
           matchLabels:
-            networking.openshift-config.syn.tools/include-config: ''
+            network.openshift-config.syn.tools/include-config: ''
     - name: configmaps_operator
       resource:
         apiVersion: v1
         kind: ConfigMap
         labelSelector:
           matchLabels:
-            networking.openshift-config.syn.tools/include-operator: ''
+            network.openshift-config.syn.tools/include-operator: ''
   serviceAccountRef:
     name: appuio-networking-manager
   template: |
@@ -191,15 +191,15 @@ spec:
     local networking = import 'appuio-networking/networking.libsonnet';
     local spec = import 'appuio-networking/spec.json';
 
-    local parseConfigmaps(configmaps) =
+    local filterConfigmaps(configmaps) =
       local nameField = function(obj) obj.metadata.name;
-      std.map(
-        function(obj) std.get(obj.data, 'spec', {}),
+      std.filter(
+        function(obj) std.objectHas(obj.data, 'spec'),
         std.sort(configmaps, nameField)
       );
 
-    local configmapsConfig = parseConfigmaps(esp.context().configmaps_config);
-    local configmapsOperator = parseConfigmaps(esp.context().configmaps_operator);
+    local configmapsConfig = filterConfigmaps(esp.context().configmaps_config);
+    local configmapsOperator = filterConfigmaps(esp.context().configmaps_operator);
 
     // Builds a new object from its input.
     // All keys which contain an object or array will be suffixed with `+` in the result.
@@ -217,18 +217,39 @@ spec:
       if !std.isObject(o[key]) && !std.isArray(o[key])
     };
 
-    local mergeSpec(configmaps, spec) = std.foldl(
-      function(a, b) a + makeMergeable(b),
-      configmaps + [ spec ],
-      {}
-    );
+    local targetMetadata(configmaps) =
+      local cmNames = std.map(
+        function(obj) obj.metadata.name,
+        configmaps
+      );
+      {
+        annotations+: {
+          'network.openshift-config.syn.tools/active-configmaps': std.manifestJsonMinified(cmNames),
+        },
+        labels+: {
+          'app.kubernetes.io/managed-by': 'espejote',
+        },
+      };
+
+    local mergeSpec(configmaps, spec) =
+      local cmSpecs = std.map(
+        function(obj) std.parseJson(std.get(obj.data, 'spec', '')),
+        configmaps
+      );
+      std.foldl(
+        function(a, b) a + makeMergeable(b),
+        cmSpecs + [ spec ],
+        {}
+      );
 
     [
       networking.Config {
+        metadata+: targetMetadata(configmapsConfig),
         spec: mergeSpec(configmapsConfig, spec.config),
       },
       networking.Operator {
-        spec: mergeSpec(configmapsConfig, spec.operator),
+        metadata+: targetMetadata(configmapsOperator),
+        spec: mergeSpec(configmapsOperator, spec.operator),
       },
     ]
   triggers:

--- a/tests/golden/pull-secret/openshift4-config/openshift4-config/05_networking_managedresource.yaml
+++ b/tests/golden/pull-secret/openshift4-config/openshift4-config/05_networking_managedresource.yaml
@@ -1,0 +1,255 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-networking-manager
+  name: appuio-networking-manager
+  namespace: openshift-config
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-openshift4-config-networking-manager
+  name: appuio:openshift4-config:networking-manager
+rules:
+  - apiGroups:
+      - operator.openshift.io
+    resourceNames:
+      - cluster
+    resources:
+      - networks
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+  - apiGroups:
+      - config.openshift.io
+    resourceNames:
+      - cluster
+    resources:
+      - networks
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-openshift4-config-networking-manager
+  name: appuio:openshift4-config:networking-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appuio:openshift4-config:networking-manager
+subjects:
+  - kind: ServiceAccount
+    name: appuio-networking-manager
+    namespace: openshift-config
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-openshift4-config-networking-manager
+  name: appuio:openshift4-config:networking-manager
+  namespace: openshift-config
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - espejote.io
+    resourceNames:
+      - appuio-networking
+    resources:
+      - jsonnetlibraries
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-openshift4-config-networking-manager
+  name: appuio:openshift4-config:networking-manager
+  namespace: openshift-config
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: appuio:openshift4-config:networking-manager
+subjects:
+  - kind: ServiceAccount
+    name: appuio-networking-manager
+    namespace: openshift-config
+---
+apiVersion: espejote.io/v1alpha1
+kind: JsonnetLibrary
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  labels:
+    app.kubernetes.io/name: appuio-networking
+  name: appuio-networking
+  namespace: openshift-config
+spec:
+  data:
+    networking.libsonnet: |
+      local configApiGroup = 'config.openshift.io';
+      local configApiVersion = '%s/v1' % configApiGroup;
+      local operatorApiGroup = 'operator.openshift.io';
+      local operatorApiVersion = '%s/v1' % operatorApiGroup;
+      local kind = 'Network';
+      local resource = 'networks';
+      local resourceName = 'cluster';
+
+      local config = {
+        apiVersion: configApiVersion,
+        kind: kind,
+        metadata: {
+          name: resourceName,
+        },
+      };
+
+      local operator = {
+        apiVersion: operatorApiVersion,
+        kind: kind,
+        metadata: {
+          name: resourceName,
+        },
+      };
+
+      {
+        configApiGroup: configApiGroup,
+        configApiVersion: configApiVersion,
+        operatorApiGroup: operatorApiGroup,
+        operatorApiVersion: operatorApiVersion,
+        kind: kind,
+        resource: resource,
+        resourceName: resourceName,
+        Config: config,
+        Operator: operator,
+      }
+    spec.json: |-
+      {
+          "config": {
+
+          },
+          "operator": {
+
+          }
+      }
+---
+apiVersion: espejote.io/v1alpha1
+kind: ManagedResource
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  labels:
+    app.kubernetes.io/name: appuio-networking
+  name: appuio-networking
+  namespace: openshift-config
+spec:
+  applyOptions:
+    force: true
+  context:
+    - name: configmaps_config
+      resource:
+        apiVersion: v1
+        kind: ConfigMap
+        labelSelector:
+          matchLabels:
+            networking.openshift-config.syn.tools/include-config: ''
+    - name: configmaps_operator
+      resource:
+        apiVersion: v1
+        kind: ConfigMap
+        labelSelector:
+          matchLabels:
+            networking.openshift-config.syn.tools/include-operator: ''
+  serviceAccountRef:
+    name: appuio-networking-manager
+  template: |
+    local esp = import 'espejote.libsonnet';
+
+    local networking = import 'appuio-networking/networking.libsonnet';
+    local spec = import 'appuio-networking/spec.json';
+
+    local parseConfigmaps(configmaps) =
+      local nameField = function(obj) obj.metadata.name;
+      std.map(
+        function(obj) std.get(obj.data, 'spec', {}),
+        std.sort(configmaps, nameField)
+      );
+
+    local configmapsConfig = parseConfigmaps(esp.context().configmaps_config);
+    local configmapsOperator = parseConfigmaps(esp.context().configmaps_operator);
+
+    // Builds a new object from its input.
+    // All keys which contain an object or array will be suffixed with `+` in the result.
+    local makeMergeable(o) = {
+      [key]+: makeMergeable(o[key])
+      for key in std.objectFields(o)
+      if std.isObject(o[key])
+    } + {
+      [key]+: o[key]
+      for key in std.objectFields(o)
+      if std.isArray(o[key])
+    } + {
+      [key]: o[key]
+      for key in std.objectFields(o)
+      if !std.isObject(o[key]) && !std.isArray(o[key])
+    };
+
+    local mergeSpec(configmaps, spec) = std.foldl(
+      function(a, b) a + makeMergeable(b),
+      configmaps + [ spec ],
+      {}
+    );
+
+    [
+      networking.Config {
+        spec: mergeSpec(configmapsConfig, spec.config),
+      },
+      networking.Operator {
+        spec: mergeSpec(configmapsConfig, spec.operator),
+      },
+    ]
+  triggers:
+    - name: jsonnetlib
+      watchResource:
+        apiVersion: espejote.io/v1alpha1
+        kind: JsonnetLibrary
+        name: appuio-networking
+    - name: networking_config
+      watchResource:
+        apiVersion: config.openshift.io/v1
+        kind: Network
+        name: cluster
+    - name: networking_operator
+      watchResource:
+        apiVersion: operator.openshift.io/v1
+        kind: Network
+        name: cluster
+    - name: configmap_config
+      watchContextResource:
+        name: configmaps_config
+    - name: configmap_operator
+      watchContextResource:
+        name: configmaps_operator

--- a/tests/golden/vsphere/openshift4-config/openshift4-config/05_networking_managedresource.yaml
+++ b/tests/golden/vsphere/openshift4-config/openshift4-config/05_networking_managedresource.yaml
@@ -175,14 +175,14 @@ spec:
         kind: ConfigMap
         labelSelector:
           matchLabels:
-            networking.openshift-config.syn.tools/include-config: ''
+            network.openshift-config.syn.tools/include-config: ''
     - name: configmaps_operator
       resource:
         apiVersion: v1
         kind: ConfigMap
         labelSelector:
           matchLabels:
-            networking.openshift-config.syn.tools/include-operator: ''
+            network.openshift-config.syn.tools/include-operator: ''
   serviceAccountRef:
     name: appuio-networking-manager
   template: |
@@ -191,15 +191,15 @@ spec:
     local networking = import 'appuio-networking/networking.libsonnet';
     local spec = import 'appuio-networking/spec.json';
 
-    local parseConfigmaps(configmaps) =
+    local filterConfigmaps(configmaps) =
       local nameField = function(obj) obj.metadata.name;
-      std.map(
-        function(obj) std.get(obj.data, 'spec', {}),
+      std.filter(
+        function(obj) std.objectHas(obj.data, 'spec'),
         std.sort(configmaps, nameField)
       );
 
-    local configmapsConfig = parseConfigmaps(esp.context().configmaps_config);
-    local configmapsOperator = parseConfigmaps(esp.context().configmaps_operator);
+    local configmapsConfig = filterConfigmaps(esp.context().configmaps_config);
+    local configmapsOperator = filterConfigmaps(esp.context().configmaps_operator);
 
     // Builds a new object from its input.
     // All keys which contain an object or array will be suffixed with `+` in the result.
@@ -217,18 +217,39 @@ spec:
       if !std.isObject(o[key]) && !std.isArray(o[key])
     };
 
-    local mergeSpec(configmaps, spec) = std.foldl(
-      function(a, b) a + makeMergeable(b),
-      configmaps + [ spec ],
-      {}
-    );
+    local targetMetadata(configmaps) =
+      local cmNames = std.map(
+        function(obj) obj.metadata.name,
+        configmaps
+      );
+      {
+        annotations+: {
+          'network.openshift-config.syn.tools/active-configmaps': std.manifestJsonMinified(cmNames),
+        },
+        labels+: {
+          'app.kubernetes.io/managed-by': 'espejote',
+        },
+      };
+
+    local mergeSpec(configmaps, spec) =
+      local cmSpecs = std.map(
+        function(obj) std.parseJson(std.get(obj.data, 'spec', '')),
+        configmaps
+      );
+      std.foldl(
+        function(a, b) a + makeMergeable(b),
+        cmSpecs + [ spec ],
+        {}
+      );
 
     [
       networking.Config {
+        metadata+: targetMetadata(configmapsConfig),
         spec: mergeSpec(configmapsConfig, spec.config),
       },
       networking.Operator {
-        spec: mergeSpec(configmapsConfig, spec.operator),
+        metadata+: targetMetadata(configmapsOperator),
+        spec: mergeSpec(configmapsOperator, spec.operator),
       },
     ]
   triggers:

--- a/tests/golden/vsphere/openshift4-config/openshift4-config/05_networking_managedresource.yaml
+++ b/tests/golden/vsphere/openshift4-config/openshift4-config/05_networking_managedresource.yaml
@@ -1,0 +1,255 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-networking-manager
+  name: appuio-networking-manager
+  namespace: openshift-config
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-openshift4-config-networking-manager
+  name: appuio:openshift4-config:networking-manager
+rules:
+  - apiGroups:
+      - operator.openshift.io
+    resourceNames:
+      - cluster
+    resources:
+      - networks
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+  - apiGroups:
+      - config.openshift.io
+    resourceNames:
+      - cluster
+    resources:
+      - networks
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-openshift4-config-networking-manager
+  name: appuio:openshift4-config:networking-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appuio:openshift4-config:networking-manager
+subjects:
+  - kind: ServiceAccount
+    name: appuio-networking-manager
+    namespace: openshift-config
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-openshift4-config-networking-manager
+  name: appuio:openshift4-config:networking-manager
+  namespace: openshift-config
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - espejote.io
+    resourceNames:
+      - appuio-networking
+    resources:
+      - jsonnetlibraries
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: appuio-openshift4-config-networking-manager
+  name: appuio:openshift4-config:networking-manager
+  namespace: openshift-config
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: appuio:openshift4-config:networking-manager
+subjects:
+  - kind: ServiceAccount
+    name: appuio-networking-manager
+    namespace: openshift-config
+---
+apiVersion: espejote.io/v1alpha1
+kind: JsonnetLibrary
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  labels:
+    app.kubernetes.io/name: appuio-networking
+  name: appuio-networking
+  namespace: openshift-config
+spec:
+  data:
+    networking.libsonnet: |
+      local configApiGroup = 'config.openshift.io';
+      local configApiVersion = '%s/v1' % configApiGroup;
+      local operatorApiGroup = 'operator.openshift.io';
+      local operatorApiVersion = '%s/v1' % operatorApiGroup;
+      local kind = 'Network';
+      local resource = 'networks';
+      local resourceName = 'cluster';
+
+      local config = {
+        apiVersion: configApiVersion,
+        kind: kind,
+        metadata: {
+          name: resourceName,
+        },
+      };
+
+      local operator = {
+        apiVersion: operatorApiVersion,
+        kind: kind,
+        metadata: {
+          name: resourceName,
+        },
+      };
+
+      {
+        configApiGroup: configApiGroup,
+        configApiVersion: configApiVersion,
+        operatorApiGroup: operatorApiGroup,
+        operatorApiVersion: operatorApiVersion,
+        kind: kind,
+        resource: resource,
+        resourceName: resourceName,
+        Config: config,
+        Operator: operator,
+      }
+    spec.json: |-
+      {
+          "config": {
+
+          },
+          "operator": {
+
+          }
+      }
+---
+apiVersion: espejote.io/v1alpha1
+kind: ManagedResource
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  labels:
+    app.kubernetes.io/name: appuio-networking
+  name: appuio-networking
+  namespace: openshift-config
+spec:
+  applyOptions:
+    force: true
+  context:
+    - name: configmaps_config
+      resource:
+        apiVersion: v1
+        kind: ConfigMap
+        labelSelector:
+          matchLabels:
+            networking.openshift-config.syn.tools/include-config: ''
+    - name: configmaps_operator
+      resource:
+        apiVersion: v1
+        kind: ConfigMap
+        labelSelector:
+          matchLabels:
+            networking.openshift-config.syn.tools/include-operator: ''
+  serviceAccountRef:
+    name: appuio-networking-manager
+  template: |
+    local esp = import 'espejote.libsonnet';
+
+    local networking = import 'appuio-networking/networking.libsonnet';
+    local spec = import 'appuio-networking/spec.json';
+
+    local parseConfigmaps(configmaps) =
+      local nameField = function(obj) obj.metadata.name;
+      std.map(
+        function(obj) std.get(obj.data, 'spec', {}),
+        std.sort(configmaps, nameField)
+      );
+
+    local configmapsConfig = parseConfigmaps(esp.context().configmaps_config);
+    local configmapsOperator = parseConfigmaps(esp.context().configmaps_operator);
+
+    // Builds a new object from its input.
+    // All keys which contain an object or array will be suffixed with `+` in the result.
+    local makeMergeable(o) = {
+      [key]+: makeMergeable(o[key])
+      for key in std.objectFields(o)
+      if std.isObject(o[key])
+    } + {
+      [key]+: o[key]
+      for key in std.objectFields(o)
+      if std.isArray(o[key])
+    } + {
+      [key]: o[key]
+      for key in std.objectFields(o)
+      if !std.isObject(o[key]) && !std.isArray(o[key])
+    };
+
+    local mergeSpec(configmaps, spec) = std.foldl(
+      function(a, b) a + makeMergeable(b),
+      configmaps + [ spec ],
+      {}
+    );
+
+    [
+      networking.Config {
+        spec: mergeSpec(configmapsConfig, spec.config),
+      },
+      networking.Operator {
+        spec: mergeSpec(configmapsConfig, spec.operator),
+      },
+    ]
+  triggers:
+    - name: jsonnetlib
+      watchResource:
+        apiVersion: espejote.io/v1alpha1
+        kind: JsonnetLibrary
+        name: appuio-networking
+    - name: networking_config
+      watchResource:
+        apiVersion: config.openshift.io/v1
+        kind: Network
+        name: cluster
+    - name: networking_operator
+      watchResource:
+        apiVersion: operator.openshift.io/v1
+        kind: Network
+        name: cluster
+    - name: configmap_config
+      watchContextResource:
+        name: configmaps_config
+    - name: configmap_operator
+      watchContextResource:
+        name: configmaps_operator

--- a/tests/motd.yml
+++ b/tests/motd.yml
@@ -2,7 +2,7 @@ parameters:
   kapitan:
     dependencies:
       - type: https
-        source: https://raw.githubusercontent.com/projectsyn/component-espejote/v0.16.1/lib/espejote.libsonnet
+        source: https://raw.githubusercontent.com/projectsyn/component-espejote/master/lib/espejote.libsonnet
         output_path: vendor/lib/espejote.libsonnet
 
   openshift4_config:

--- a/tests/pull-secret.yml
+++ b/tests/pull-secret.yml
@@ -1,6 +1,10 @@
-# Overwrite parameters here
-
 parameters:
+  kapitan:
+    dependencies:
+      - type: https
+        source: https://raw.githubusercontent.com/projectsyn/component-espejote/master/lib/espejote.libsonnet
+        output_path: vendor/lib/espejote.libsonnet
+
   openshift4_config:
     globalPullSecrets:
       ghcr.io:


### PR DESCRIPTION
This PR adds functionality to manage the configuration and operator for OpenShift Networking.
Additionally it allows other components to supply configmaps with additional specs to merge into the applied resources.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
